### PR TITLE
[UI 구현] Detail Page UI 구현

### DIFF
--- a/src/app/pages/DetailPage.tsx
+++ b/src/app/pages/DetailPage.tsx
@@ -63,12 +63,6 @@ const DetailPage = () => {
               router.back();
             }}
           />
-          <ToolbarButton
-            name={IconName.trash}
-            onPress={() => {
-              // TODO: 노트 삭제 기능이 필요할 지 논의하기
-            }}
-          />
         </View>
         {/* 컨텐츠 */}
         {note !== undefined && note.created_at instanceof Date && (
@@ -86,10 +80,11 @@ const DetailPage = () => {
               <Divider />
               <DetailNoteCell
                 note={note}
-                onPressEdit={() => {
+                onPress={() => {
                   router.push({
                     pathname: "/pages/EditPage",
                     params: {
+                      editableData: JSON.stringify(false),
                       feelsLikeTempData: 30,
                       noteData: JSON.stringify(note),
                     },
@@ -193,13 +188,13 @@ const DetailOndoCell = ({ ondo }: { ondo: number }) => {
 
 const DetailNoteCell = ({
   note,
-  onPressEdit,
+  onPress,
 }: {
   note: NoteItem;
-  onPressEdit: () => void;
+  onPress: () => void;
 }) => {
   return (
-    <View>
+    <TouchableOpacity onPress={onPress}>
       <View
         style={{
           backgroundColor: Colors.white40,
@@ -224,7 +219,6 @@ const DetailNoteCell = ({
           >
             {"Note\nOnthemood"}
           </Text>
-          <ToolbarButton name={IconName.edit} onPress={onPressEdit} />
         </View>
         <View style={{ width: "100%" }}>
           <Text
@@ -235,7 +229,7 @@ const DetailNoteCell = ({
           </Text>
         </View>
       </View>
-    </View>
+    </TouchableOpacity>
   );
 };
 
@@ -244,7 +238,7 @@ export default DetailPage;
 const styles = StyleSheet.create({
   container: {
     flex: 1,
-    margin: 12,
+    marginHorizontal: 12,
   },
   topToolbar: {
     flexDirection: "row",
@@ -256,5 +250,6 @@ const styles = StyleSheet.create({
   contentContainer: {
     justifyContent: "space-between",
     flex: 1,
+    marginTop: 16,
   },
 });

--- a/src/app/pages/DetailPage.tsx
+++ b/src/app/pages/DetailPage.tsx
@@ -1,0 +1,33 @@
+import { StyleSheet, Text, View } from "react-native";
+import React, { useEffect, useState } from "react";
+import { useLocalSearchParams } from "expo-router";
+import { getNoteDetail } from "@/src/api/endpoints/daily-notes";
+
+const DetailPage = () => {
+  const { noteData } = useLocalSearchParams();
+  const [note, setNote] = useState<NoteItem | undefined>(undefined);
+
+  useEffect(() => {
+    try {
+      if (Array.isArray(noteData))
+        throw new Error("noteData가 string[] 타입입니다");
+
+      if (noteData) {
+        const parsedNote = JSON.parse(noteData);
+        setNote(parsedNote);
+      }
+    } catch (error) {
+      console.error("유효하지 않은 JSON을 변환하려 합니다 :", error);
+    }
+  }, []);
+
+  return (
+    <View>
+      <Text>{note?.content}</Text>
+    </View>
+  );
+};
+
+export default DetailPage;
+
+const styles = StyleSheet.create({});

--- a/src/app/pages/DetailPage.tsx
+++ b/src/app/pages/DetailPage.tsx
@@ -6,6 +6,7 @@ import { ToolbarButton } from "@/src/components/ToolbarButton";
 import Icon, { IconName } from "@/src/components/Icon";
 import typography from "@/src/styles/Typography";
 import { Colors, OndoColors } from "@/src/styles/Colors";
+import { toDateString } from "@/src/utils/dateUtils";
 
 const DetailPage = () => {
   const { noteData } = useLocalSearchParams();
@@ -60,7 +61,7 @@ const DetailPage = () => {
             {/* 날짜 / 지역 */}
             <View style={{ flex: 1, gap: 8 }}>
               <Text style={[typography.heading1, { color: Colors.black100 }]}>
-                {note.created_at.toDateString()}
+                {toDateString(note.created_at)}
               </Text>
 
               <View

--- a/src/app/pages/DetailPage.tsx
+++ b/src/app/pages/DetailPage.tsx
@@ -32,7 +32,7 @@ const DetailPage = () => {
     } catch (error) {
       console.error("유효하지 않은 JSON을 변환하려 합니다 :", error);
     }
-  }, []);
+  }, [noteData]);
 
   const Divider = () => (
     <View
@@ -89,7 +89,10 @@ const DetailPage = () => {
                 onPressEdit={() => {
                   router.push({
                     pathname: "/pages/EditPage",
-                    params: { temperature: note.custom_temp },
+                    params: {
+                      feelsLikeTempData: 30,
+                      noteData: JSON.stringify(note),
+                    },
                   });
                 }}
               />

--- a/src/app/pages/DetailPage.tsx
+++ b/src/app/pages/DetailPage.tsx
@@ -1,7 +1,11 @@
 import { StyleSheet, Text, View } from "react-native";
 import React, { useEffect, useState } from "react";
-import { useLocalSearchParams } from "expo-router";
-import { getNoteDetail } from "@/src/api/endpoints/daily-notes";
+import { Stack, useLocalSearchParams } from "expo-router";
+import { SafeAreaView } from "react-native-safe-area-context";
+import { ToolbarButton } from "@/src/components/ToolbarButton";
+import Icon, { IconName } from "@/src/components/Icon";
+import typography from "@/src/styles/Typography";
+import { Colors, OndoColors } from "@/src/styles/Colors";
 
 const DetailPage = () => {
   const { noteData } = useLocalSearchParams();
@@ -14,20 +18,126 @@ const DetailPage = () => {
 
       if (noteData) {
         const parsedNote = JSON.parse(noteData);
-        setNote(parsedNote);
+        setNote({
+          id: parsedNote.id,
+          location: parsedNote.location,
+          custom_temp: parsedNote.custom_temp,
+          content: parsedNote.content,
+          created_at: new Date(parsedNote.created_at),
+          updated_at: new Date(parsedNote.updated_at),
+        });
       }
     } catch (error) {
       console.error("유효하지 않은 JSON을 변환하려 합니다 :", error);
     }
   }, []);
 
+  console.log("Type:", typeof note?.created_at);
+
   return (
-    <View>
-      <Text>{note?.content}</Text>
+    <View
+      style={{
+        flex: 1,
+        backgroundColor: OndoColors.get(15),
+      }}
+    >
+      <Stack.Screen options={{ headerShown: false }} />
+
+      <SafeAreaView style={styles.container}>
+        {/* 툴바 */}
+        <View style={styles.topToolbar}>
+          <ToolbarButton name={IconName.back} onPress={() => {}} />
+          <ToolbarButton name={IconName.trash} onPress={() => {}} />
+        </View>
+        {/* 컨텐츠 */}
+        {note !== undefined && note.created_at instanceof Date && (
+          <View
+            style={{
+              justifyContent: "space-between",
+              flex: 1,
+            }}
+          >
+            {/* 날짜 / 지역 */}
+            <View style={{ flex: 1, gap: 8 }}>
+              <Text style={[typography.heading1, { color: Colors.black100 }]}>
+                {note.created_at.toDateString()}
+              </Text>
+
+              <View
+                style={{ flexDirection: "row", alignItems: "center", gap: 2 }}
+              >
+                <Icon name={IconName.location} size={14} />
+                <Text style={[typography.label1, { color: Colors.black100 }]}>
+                  {note?.location}
+                </Text>
+              </View>
+            </View>
+            {/* 노트 정보 */}
+            <View>
+              {/* 코드 */}
+              <View
+                style={{
+                  flexDirection: "row",
+                  justifyContent: "space-between",
+                }}
+              >
+                <View style={{ flexDirection: "row" }}>
+                  <Text>{"Note\nMood Code"}</Text>
+                  <Icon name={IconName.info} />
+                </View>
+                <Text>#C7FBEE</Text>
+              </View>
+              <View
+                style={{
+                  height: 1,
+                  backgroundColor: "gray",
+                  marginVertical: 10,
+                }}
+              />
+              {/* 온도 */}
+              <View>
+                <View
+                  style={{
+                    flexDirection: "row",
+                    justifyContent: "space-between",
+                  }}
+                >
+                  <Text>{"Note\nOnde"}</Text>
+
+                  <Text>2°</Text>
+                </View>
+              </View>
+              <View
+                style={{
+                  height: 1,
+                  backgroundColor: "gray",
+                  marginVertical: 10,
+                }}
+              />
+              {/* 노트 */}
+              <View>
+                <Text>{note?.content}</Text>
+              </View>
+            </View>
+          </View>
+        )}
+      </SafeAreaView>
     </View>
   );
 };
 
 export default DetailPage;
 
-const styles = StyleSheet.create({});
+const styles = StyleSheet.create({
+  container: {
+    flex: 1,
+    margin: 12,
+  },
+  topToolbar: {
+    flexDirection: "row",
+    paddingVertical: 12,
+    marginHorizontal: 4,
+    justifyContent: "space-between",
+    alignItems: "center",
+  },
+});

--- a/src/app/pages/DetailPage.tsx
+++ b/src/app/pages/DetailPage.tsx
@@ -1,12 +1,15 @@
-import { StyleSheet, Text, TouchableOpacity, View } from "react-native";
 import React, { useEffect, useState } from "react";
+import { StyleSheet, View } from "react-native";
 import { router, Stack, useLocalSearchParams } from "expo-router";
 import { SafeAreaView } from "react-native-safe-area-context";
 import { ToolbarButton } from "@/src/components/ToolbarButton";
-import Icon, { IconName } from "@/src/components/Icon";
-import typography from "@/src/styles/Typography";
-import { Colors, OndoColors } from "@/src/styles/Colors";
-import { toDateString } from "@/src/utils/dateUtils";
+import { IconName } from "@/src/components/Icon";
+import { OndoColors } from "@/src/styles/Colors";
+import DateLocationCell from "@/src/components/detailPage/DateLocationCell";
+import PageDivider from "@/src/components/detailPage/PageDivider";
+import ColorCodeCell from "@/src/components/detailPage/ColorCodeCell";
+import OndoCell from "@/src/components/detailPage/OndoCell";
+import NoteCell from "@/src/components/detailPage/NoteCell";
 
 const DetailPage = () => {
   const { noteData } = useLocalSearchParams();
@@ -34,16 +37,6 @@ const DetailPage = () => {
     }
   }, [noteData]);
 
-  const Divider = () => (
-    <View
-      style={{
-        height: 1,
-        backgroundColor: Colors.black18,
-        marginVertical: 24,
-      }}
-    />
-  );
-
   return (
     <View
       style={{
@@ -68,17 +61,17 @@ const DetailPage = () => {
         {note !== undefined && note.created_at instanceof Date && (
           <View style={styles.contentContainer}>
             {/* 날짜 / 지역 */}
-            <DetailDateLocationCell
+            <DateLocationCell
               createdAt={note.created_at}
               location={note.location}
             />
             {/* 노트 정보 */}
             <View>
-              <DetailColorCodeCell ondo={note.custom_temp} />
-              <Divider />
-              <DetailOndoCell ondo={note.custom_temp} />
-              <Divider />
-              <DetailNoteCell
+              <ColorCodeCell ondo={note.custom_temp} />
+              <PageDivider />
+              <OndoCell ondo={note.custom_temp} />
+              <PageDivider />
+              <NoteCell
                 note={note}
                 onPress={() => {
                   router.push({
@@ -96,140 +89,6 @@ const DetailPage = () => {
         )}
       </SafeAreaView>
     </View>
-  );
-};
-
-const DetailDateLocationCell = ({
-  createdAt,
-  location,
-}: {
-  createdAt: Date;
-  location: string;
-}) => (
-  <View style={{ flex: 1, gap: 4 }}>
-    <Text style={[typography.heading1, { color: Colors.black100 }]}>
-      {toDateString(createdAt)}
-    </Text>
-
-    <View style={{ flexDirection: "row", alignItems: "center", gap: 2 }}>
-      <Icon name={IconName.location} size={14} />
-      <Text style={[typography.label1, { color: Colors.black100 }]}>
-        {location}
-      </Text>
-    </View>
-  </View>
-);
-
-const DetailColorCodeCell = ({ ondo }: { ondo: number }) => (
-  <View
-    style={{
-      flexDirection: "row",
-      justifyContent: "space-between",
-    }}
-  >
-    <View style={{ flexDirection: "row" }}>
-      <Text
-        style={[
-          typography.label1,
-          { color: Colors.black100, fontWeight: "bold" },
-        ]}
-      >
-        {"Note\nMood Code"}
-      </Text>
-
-      <TouchableOpacity
-        style={{ marginHorizontal: 8 }}
-        onPress={() => {
-          // TODO: tooltip 추가하기
-        }}
-      >
-        <Icon name={IconName.info} />
-      </TouchableOpacity>
-    </View>
-    <Text
-      style={[
-        typography.title2,
-        {
-          color: Colors.black100,
-          fontWeight: "bold",
-          textDecorationLine: "underline",
-        },
-      ]}
-    >
-      {OndoColors.get(ondo)}
-    </Text>
-  </View>
-);
-
-const DetailOndoCell = ({ ondo }: { ondo: number }) => {
-  return (
-    <View
-      style={{
-        flexDirection: "row",
-        justifyContent: "space-between",
-      }}
-    >
-      <Text
-        style={[
-          typography.label1,
-          { color: Colors.black100, fontWeight: "bold" },
-        ]}
-      >
-        {"Note\nOndo"}
-      </Text>
-
-      <View style={{ flexDirection: "row" }}>
-        <Text style={[typography.display1]}>{ondo}</Text>
-        <Text style={[typography.display2]}>°</Text>
-      </View>
-    </View>
-  );
-};
-
-const DetailNoteCell = ({
-  note,
-  onPress,
-}: {
-  note: NoteItem;
-  onPress: () => void;
-}) => {
-  return (
-    <TouchableOpacity onPress={onPress}>
-      <View
-        style={{
-          backgroundColor: Colors.white40,
-          paddingHorizontal: 16,
-          paddingVertical: 24,
-          borderRadius: 16,
-          gap: 40,
-        }}
-      >
-        <View
-          style={{
-            flexDirection: "row",
-            paddingHorizontal: 0,
-            justifyContent: "space-between",
-          }}
-        >
-          <Text
-            style={[
-              typography.label1,
-              { color: Colors.black100, fontWeight: "bold" },
-            ]}
-          >
-            {"Note\nOnthemood"}
-          </Text>
-        </View>
-        <View style={{ width: "100%" }}>
-          <Text
-            numberOfLines={4}
-            style={[typography.body, { height: 25.6 * 4, textOverflow: "..." }]}
-          >
-            {note?.content}
-          </Text>
-        </View>
-      </View>
-    </TouchableOpacity>
   );
 };
 

--- a/src/app/pages/EditPage.tsx
+++ b/src/app/pages/EditPage.tsx
@@ -18,12 +18,15 @@ import { router, useLocalSearchParams } from "expo-router";
 import React, { useState } from "react";
 import { OndoColors } from "@/src/styles/Colors";
 import { postNote } from "@/src/api/endpoints/daily-notes";
+import { toDateString } from "@/src/utils/dateUtils";
 
 const EditPage = () => {
-  const { date, temperature } = useLocalSearchParams();
+  const { temperature } = useLocalSearchParams();
 
-  const isoDateString = Array.isArray(date) ? date[0] : date;
-  const parsedDate = isoDateString ? new Date(isoDateString) : null;
+  // const isoDateString = Array.isArray(date) ? date[0] : date;
+  // const parsedDate = isoDateString ? new Date(isoDateString) : null;
+
+  const date = new Date();
 
   const parsedTemperature = Array.isArray(temperature)
     ? Number(temperature[0])
@@ -48,9 +51,7 @@ const EditPage = () => {
                   router.back();
                 }}
               />
-              <Text style={typography.heading2}>
-                {parsedDate?.toLocaleDateString("ko-KR")}
-              </Text>
+              <Text style={typography.heading2}>{toDateString(date)}</Text>
               <ToolbarButton
                 name={IconName.check}
                 onPress={async () => {

--- a/src/components/calendar/Calendar.tsx
+++ b/src/components/calendar/Calendar.tsx
@@ -28,8 +28,11 @@ const Calendar = ({ date, updateDate }: CalendarProps) => {
   }, [notes]);
 
   useEffect(() => {
-    // getWeather({ latitude: 128.59, longitude: 35.87 }).then((result) => {
-    //   // 날씨 데이터 받아와서 처리해주기
+    // getWeather({
+    //   latitude: 35.87,
+    //   longitude: 128.59,
+    // }).then((result) => {
+    //   console.log(result);
     // });
   }, []);
 

--- a/src/components/calendar/ThreadCalendarCell.tsx
+++ b/src/components/calendar/ThreadCalendarCell.tsx
@@ -4,6 +4,7 @@ import React from "react";
 import { StyleSheet, Text, View } from "react-native";
 import Icon, { IconName } from "../Icon";
 import { ToolbarButton } from "../ToolbarButton";
+import { router } from "expo-router";
 
 type ThreadCalendarCellProps = {
   date: Date;
@@ -32,7 +33,15 @@ const ThreadCalendarCell = ({ date, note }: ThreadCalendarCellProps) => {
       <View style={{ flexDirection: "row", paddingHorizontal: 0 }}>
         <Text style={styles.todayCellTitle}>{"Today\nMood Note"}</Text>
         {note != undefined ? (
-          <ToolbarButton name={IconName.arrow} onPress={() => {}} />
+          <ToolbarButton
+            name={IconName.arrow}
+            onPress={() => {
+              router.push({
+                pathname: "/pages/DetailPage",
+                params: { noteData: JSON.stringify(note) },
+              });
+            }}
+          />
         ) : (
           <View />
         )}

--- a/src/components/calendar/ThreadCalendarCell.tsx
+++ b/src/components/calendar/ThreadCalendarCell.tsx
@@ -5,6 +5,8 @@ import { StyleSheet, Text, View } from "react-native";
 import Icon, { IconName } from "../Icon";
 import { ToolbarButton } from "../ToolbarButton";
 import { router } from "expo-router";
+import { isDateToday } from "@/src/utils/dateUtils";
+import EditPage from "@/src/app/pages/EditPage";
 
 type ThreadCalendarCellProps = {
   date: Date;
@@ -36,10 +38,17 @@ const ThreadCalendarCell = ({ date, note }: ThreadCalendarCellProps) => {
           <ToolbarButton
             name={IconName.arrow}
             onPress={() => {
-              router.push({
-                pathname: "/pages/DetailPage",
-                params: { noteData: JSON.stringify(note) },
-              });
+              if (isDateToday(note.created_at)) {
+                router.push({
+                  pathname: "/pages/EditPage",
+                  params: { temperature: 30 },
+                });
+              } else {
+                router.push({
+                  pathname: "/pages/DetailPage",
+                  params: { noteData: JSON.stringify(note) },
+                });
+              }
             }}
           />
         ) : (

--- a/src/components/calendar/ThreadCalendarCell.tsx
+++ b/src/components/calendar/ThreadCalendarCell.tsx
@@ -41,7 +41,12 @@ const ThreadCalendarCell = ({ date, note }: ThreadCalendarCellProps) => {
               if (isDateToday(note.created_at)) {
                 router.push({
                   pathname: "/pages/EditPage",
-                  params: { temperature: 30 },
+                  // TODO: feelsLikeTempData를 오늘의 체감온도로 수정해주기
+                  // 이 데이터는 note에 들어있을 예정이라, note에서 값 가져와도 좋을 것 같음
+                  params: {
+                    feelsLikeTempData: 30,
+                    noteData: JSON.stringify(note),
+                  },
                 });
               } else {
                 router.push({

--- a/src/components/calendar/TodayNoteCell.tsx
+++ b/src/components/calendar/TodayNoteCell.tsx
@@ -45,7 +45,10 @@ const TodayNoteCell = ({ date, location, temperature }: TodayNoteCellProps) => {
           onPress={() =>
             router.push({
               pathname: "/pages/EditPage",
-              params: { temperature: temperature, date: date.toISOString() },
+              params: {
+                feelsLikeTempData: temperature,
+                date: date.toISOString(),
+              },
             })
           }
         >

--- a/src/components/detailPage/ColorCodeCell.tsx
+++ b/src/components/detailPage/ColorCodeCell.tsx
@@ -1,0 +1,48 @@
+import { Text, TouchableOpacity, View } from "react-native";
+import React from "react";
+import Icon, { IconName } from "@/src/components/Icon";
+import typography from "@/src/styles/Typography";
+import { Colors, OndoColors } from "@/src/styles/Colors";
+
+const ColorCodeCell = ({ ondo }: { ondo: number }) => (
+  <View
+    style={{
+      flexDirection: "row",
+      justifyContent: "space-between",
+    }}
+  >
+    <View style={{ flexDirection: "row" }}>
+      <Text
+        style={[
+          typography.label1,
+          { color: Colors.black100, fontWeight: "bold" },
+        ]}
+      >
+        {"Note\nMood Code"}
+      </Text>
+
+      <TouchableOpacity
+        style={{ marginHorizontal: 8 }}
+        onPress={() => {
+          // TODO: tooltip 추가하기
+        }}
+      >
+        <Icon name={IconName.info} />
+      </TouchableOpacity>
+    </View>
+    <Text
+      style={[
+        typography.title2,
+        {
+          color: Colors.black100,
+          fontWeight: "bold",
+          textDecorationLine: "underline",
+        },
+      ]}
+    >
+      {OndoColors.get(ondo)}
+    </Text>
+  </View>
+);
+
+export default ColorCodeCell;

--- a/src/components/detailPage/DateLocationCell.tsx
+++ b/src/components/detailPage/DateLocationCell.tsx
@@ -1,0 +1,28 @@
+import { Colors } from "@/src/styles/Colors";
+import typography from "@/src/styles/Typography";
+import { toDateString } from "@/src/utils/dateUtils";
+import { View, Text } from "react-native";
+import Icon, { IconName } from "../Icon";
+
+const DateLocationCell = ({
+  createdAt,
+  location,
+}: {
+  createdAt: Date;
+  location: string;
+}) => (
+  <View style={{ flex: 1, gap: 4 }}>
+    <Text style={[typography.heading1, { color: Colors.black100 }]}>
+      {toDateString(createdAt)}
+    </Text>
+
+    <View style={{ flexDirection: "row", alignItems: "center", gap: 2 }}>
+      <Icon name={IconName.location} size={14} />
+      <Text style={[typography.label1, { color: Colors.black100 }]}>
+        {location}
+      </Text>
+    </View>
+  </View>
+);
+
+export default DateLocationCell;

--- a/src/components/detailPage/NoteCell.tsx
+++ b/src/components/detailPage/NoteCell.tsx
@@ -1,0 +1,53 @@
+import { Text, TouchableOpacity, View } from "react-native";
+import React from "react";
+import typography from "@/src/styles/Typography";
+import { Colors } from "@/src/styles/Colors";
+
+const NoteCell = ({
+  note,
+  onPress,
+}: {
+  note: NoteItem;
+  onPress: () => void;
+}) => {
+  return (
+    <TouchableOpacity onPress={onPress}>
+      <View
+        style={{
+          backgroundColor: Colors.white40,
+          paddingHorizontal: 16,
+          paddingVertical: 24,
+          borderRadius: 16,
+          gap: 40,
+        }}
+      >
+        <View
+          style={{
+            flexDirection: "row",
+            paddingHorizontal: 0,
+            justifyContent: "space-between",
+          }}
+        >
+          <Text
+            style={[
+              typography.label1,
+              { color: Colors.black100, fontWeight: "bold" },
+            ]}
+          >
+            {"Note\nOnthemood"}
+          </Text>
+        </View>
+        <View style={{ width: "100%" }}>
+          <Text
+            numberOfLines={4}
+            style={[typography.body, { height: 25.6 * 4, textOverflow: "..." }]}
+          >
+            {note?.content}
+          </Text>
+        </View>
+      </View>
+    </TouchableOpacity>
+  );
+};
+
+export default NoteCell;

--- a/src/components/detailPage/OndoCell.tsx
+++ b/src/components/detailPage/OndoCell.tsx
@@ -1,0 +1,32 @@
+import { Text, View } from "react-native";
+
+import typography from "@/src/styles/Typography";
+import React from "react";
+import { Colors } from "@/src/styles/Colors";
+
+const OndoCell = ({ ondo }: { ondo: number }) => {
+  return (
+    <View
+      style={{
+        flexDirection: "row",
+        justifyContent: "space-between",
+      }}
+    >
+      <Text
+        style={[
+          typography.label1,
+          { color: Colors.black100, fontWeight: "bold" },
+        ]}
+      >
+        {"Note\nOndo"}
+      </Text>
+
+      <View style={{ flexDirection: "row" }}>
+        <Text style={[typography.display1]}>{ondo}</Text>
+        <Text style={[typography.display2]}>°</Text>
+      </View>
+    </View>
+  );
+};
+
+export default OndoCell;

--- a/src/components/detailPage/PageDivider.tsx
+++ b/src/components/detailPage/PageDivider.tsx
@@ -1,0 +1,16 @@
+import { Colors } from "@/src/styles/Colors";
+import { View } from "react-native";
+
+const PageDivider = () => {
+  return (
+    <View
+      style={{
+        height: 1,
+        backgroundColor: Colors.black18,
+        marginVertical: 24,
+      }}
+    />
+  );
+};
+
+export default PageDivider;

--- a/src/components/editpage/NoteEditor.tsx
+++ b/src/components/editpage/NoteEditor.tsx
@@ -8,14 +8,23 @@ type NoteEditorProps = {
   keywordList: string[];
   memo: string;
   onMemoChanged: (memo: string) => void;
+  autoFocus?: boolean;
+  defaultValue?: string;
 };
 
-const NoteEditor = ({ keywordList, memo, onMemoChanged }: NoteEditorProps) => {
+const NoteEditor = ({
+  keywordList,
+  memo,
+  onMemoChanged,
+  autoFocus = true,
+  defaultValue = "",
+}: NoteEditorProps) => {
   return (
     <View style={styles.noteEditorContainer}>
       <View style={{ flex: 1 }}>
         <Keywords keywordList={keywordList} />
         <TextInput
+          defaultValue={defaultValue}
           style={styles.noteEditor}
           multiline={true}
           numberOfLines={3}
@@ -24,7 +33,7 @@ const NoteEditor = ({ keywordList, memo, onMemoChanged }: NoteEditorProps) => {
             "오늘 나만의 온도는 어땠나요?\n오늘의 하루를 컬러와 간단한 문장으로 표현해보세요."
           }
           placeholderTextColor={Colors.black40}
-          autoFocus
+          autoFocus={autoFocus}
           onChangeText={(memo) => {
             onMemoChanged(memo);
           }}

--- a/src/components/editpage/TemperatureSlider.tsx
+++ b/src/components/editpage/TemperatureSlider.tsx
@@ -7,17 +7,15 @@ import typography from "@/src/styles/Typography";
 
 type TemperatureSliderProps = {
   feelsLikeTemp: number;
-  initialTemp?: number;
+  moodTemp: number;
   changeMoodTemp: (temperature: number) => void;
 };
 
 const TemperatureSlider = ({
   feelsLikeTemp,
-  initialTemp = feelsLikeTemp,
+  moodTemp,
   changeMoodTemp,
 }: TemperatureSliderProps) => {
-  const [temperature, setTemperature] = useState(initialTemp);
-
   const minValue = -40;
   const maxValue = 40;
 
@@ -46,7 +44,7 @@ const TemperatureSlider = ({
                 )
               )}
             </View>
-            {temperature === feelsLikeTemp ? null : (
+            {moodTemp === feelsLikeTemp ? null : (
               <View
                 style={[
                   styles.feelsLikeTempLabelRow,
@@ -70,10 +68,9 @@ const TemperatureSlider = ({
             trackRightPadding={-1}
             minimumValue={minValue}
             maximumValue={maxValue}
-            value={initialTemp}
+            value={moodTemp}
             onValueChange={(value) => {
-              setTemperature(value[0]);
-              changeMoodTemp(temperature);
+              changeMoodTemp(value[0]);
             }}
             maximumTrackTintColor="transparent"
             minimumTrackTintColor="transparent"
@@ -91,21 +88,17 @@ const TemperatureSlider = ({
         style={[
           styles.sliderThumbContainer,
           {
-            left: `${
-              ((temperature - minValue) / (maxValue - minValue)) * 100
-            }%`,
+            left: `${((moodTemp - minValue) / (maxValue - minValue)) * 100}%`,
           },
         ]}
       >
         <View style={[styles.degreeTag]}>
           <Text style={[styles.degreeTopLabel]}>
-            {temperature === feelsLikeTemp
-              ? "오늘의 체감온도"
-              : "나의 온도무드"}
+            {moodTemp === feelsLikeTemp ? "오늘의 체감온도" : "나의 온도무드"}
           </Text>
           {/* TODO: 온도에 따라 색상 변경되도록 수정하기 */}
           <Text style={[styles.degreeTagLabel, { color: Colors.white100 }]}>
-            {temperature}°
+            {moodTemp}°
           </Text>
         </View>
         <View style={styles.degreeBottomTriangle} />

--- a/src/components/editpage/TemperatureSlider.tsx
+++ b/src/components/editpage/TemperatureSlider.tsx
@@ -7,14 +7,16 @@ import typography from "@/src/styles/Typography";
 
 type TemperatureSliderProps = {
   feelsLikeTemp: number;
+  initialTemp?: number;
   changeMoodTemp: (temperature: number) => void;
 };
 
 const TemperatureSlider = ({
   feelsLikeTemp,
+  initialTemp = feelsLikeTemp,
   changeMoodTemp,
 }: TemperatureSliderProps) => {
-  const [temperature, setTemperature] = useState(feelsLikeTemp);
+  const [temperature, setTemperature] = useState(initialTemp);
 
   const minValue = -40;
   const maxValue = 40;
@@ -68,7 +70,7 @@ const TemperatureSlider = ({
             trackRightPadding={-1}
             minimumValue={minValue}
             maximumValue={maxValue}
-            value={temperature}
+            value={initialTemp}
             onValueChange={(value) => {
               setTemperature(value[0]);
               changeMoodTemp(temperature);

--- a/src/utils/dateUtils.ts
+++ b/src/utils/dateUtils.ts
@@ -39,3 +39,11 @@ export const isSameDay = (from: Date, target: Date): boolean => {
     from.getDate() == target.getDate()
   );
 };
+
+/// yyyy.MM.dd. 의 형식으로 Date 데이터를 string 으로 변환해줍니다.
+export const toDateString = (date: Date): string => {
+  const year = date.getFullYear();
+  const month = (date.getMonth() + 1).toString().padStart(2, "0");
+  const day = date.getDate().toString().padStart(2, "0");
+  return `${year}.${month}.${day}.`;
+};


### PR DESCRIPTION
## 구현 영상 또는 이미지
|디테일페이지 1|디테일페이지 2|
|---|---|
|![Simulator Screenshot - iPhone 15 Pro - 2025-03-24 at 21 20 14](https://github.com/user-attachments/assets/8719cf15-d446-48ce-a1ee-6875123c0858)|![Simulator Screenshot - iPhone 15 Pro - 2025-03-24 at 21 20 10](https://github.com/user-attachments/assets/ec6e2ba2-bde5-497f-87da-653ea3e6f834)|


## 세부 사항
- Detail Page의 UI 레이아웃 및 컴포넌트를 추가하였습니다.
- EditPage로 이동 시 수정 가능 여부 (editable)을 전달할 수 있도록 props를 추가하였습니다.


## 기타 질문 및 특이 사항
- 페이지 진입 시 `useLocalSearchParams()` 를 통해서 데이터를 전달하고 있는데, 이 값들을 정제하기 위해 useEffect를 사용하고 있습니다. 초기값을 부여하고, 데이터가 유효하다면 파싱해서 데이터를 변경하고 이에 따라 렌더링이 일어나도록 setState로 값들을 받고있는데, 적절하게 처리되고 있는지 궁금합니다.
 
## 체크 리스트 (아래 사항들이 전부 체크되어야만 merge)
- [x]  필요한 test들을 완료하였고 기능이 제대로 실행되는지 확인 하였습니다.
- [x]  코드 스타일 가이드에 맞추어 코드를 작성 하였습니다.
- [x]  제가 의도한 파일들과 수정 사항들만 커밋이 된 것을 확인 하였습니다.
- [x]  본 수정 사항들을 팀원들과 사전에 상의하였고 팀원들 모두 해당 PR에 대하여 알고 있습니다.
