### PR TITLE
[로직 추가] EditPage 진입 시 조건에 따른 로직 추가

### DIFF
--- a/src/app/pages/EditPage.tsx
+++ b/src/app/pages/EditPage.tsx
@@ -4,6 +4,7 @@ import {
   SafeAreaView,
   StyleSheet,
   Text,
+  TextInput,
   View,
 } from "react-native";
 
@@ -14,12 +15,15 @@ import NoteEditor from "@/src/components/editpage/NoteEditor";
 import TemperatureSlider from "@/src/components/editpage/TemperatureSlider";
 import typography from "@/src/styles/Typography";
 import { router, useLocalSearchParams } from "expo-router";
-import React, { useEffect, useState } from "react";
+import React, { useEffect, useRef, useState } from "react";
 import { OndoColors } from "@/src/styles/Colors";
 import { editNote, postNote } from "@/src/api/endpoints/daily-notes";
 import { toDateString } from "@/src/utils/dateUtils";
 
 const EditPage = () => {
+  // 화면 진입 시 TextInput에 focus를 부여할 때 사용
+  const inputRef = useRef<TextInput>(null);
+
   const { feelsLikeTempData, noteData, editableData } = useLocalSearchParams();
 
   const date = new Date();
@@ -49,6 +53,7 @@ const EditPage = () => {
       if (Array.isArray(noteData))
         throw new Error("noteData가 string[] 타입입니다");
 
+      // 노트 데이터가 있는 경우 (기존 작성 데이터 O)
       if (noteData) {
         const parsedNote = JSON.parse(noteData);
         // TODO: JSON -> NoteItem 만드는 Util 함수 추가하기
@@ -62,7 +67,16 @@ const EditPage = () => {
         });
         setMyMoodOndo(parsedNote.custom_temp);
         setMemo(parsedNote.content);
-      } else {
+      }
+      // 노트 데이터가 없는 경우 (처음 작성하는 경우)
+      else {
+        // 페이지가 로드되고 잠시 후 키보드에 포커스를 부여하기
+        setTimeout(() => {
+          requestAnimationFrame(() => {
+            inputRef.current?.focus();
+          });
+        }, 500);
+
         setMyMoodOndo(Number(feelsLikeTempData));
       }
     } catch (error) {
@@ -164,7 +178,8 @@ const EditPage = () => {
                 memo={memo}
                 onMemoChanged={(memo) => setMemo(memo)}
                 defaultValue={note?.content}
-                autoFocus={!note}
+                ref={inputRef}
+                autoFocus={false}
               />
             </View>
           </View>

--- a/src/app/pages/EditPage.tsx
+++ b/src/app/pages/EditPage.tsx
@@ -33,7 +33,7 @@ const EditPage = () => {
   const [editable, setEditable] = useState(true);
 
   const [myMoodOndo, setMyMoodOndo] = useState(feelsLikeTemp);
-  const [memo, setMemo] = useState(note ? note.content : "");
+  const [memo, setMemo] = useState("");
 
   useEffect(() => {
     try {

--- a/src/app/pages/EditPage.tsx
+++ b/src/app/pages/EditPage.tsx
@@ -50,10 +50,10 @@ const EditPage = () => {
 
   useEffect(() => {
     try {
-      if (Array.isArray(noteData))
+      if (Array.isArray(noteData)) {
         throw new Error("noteData가 string[] 타입입니다");
+      }
 
-      // 노트 데이터가 있는 경우 (기존 작성 데이터 O)
       if (noteData) {
         const parsedNote = JSON.parse(noteData);
         // TODO: JSON -> NoteItem 만드는 Util 함수 추가하기
@@ -67,22 +67,22 @@ const EditPage = () => {
         });
         setMyMoodOndo(parsedNote.custom_temp);
         setMemo(parsedNote.content);
-      }
-      // 노트 데이터가 없는 경우 (처음 작성하는 경우)
-      else {
-        // 페이지가 로드되고 잠시 후 키보드에 포커스를 부여하기
-        setTimeout(() => {
+      } else {
+        const focusTimeout = setTimeout(() => {
           requestAnimationFrame(() => {
             inputRef.current?.focus();
           });
         }, 500);
 
         setMyMoodOndo(Number(feelsLikeTempData));
+
+        // Cleanup function
+        return () => clearTimeout(focusTimeout);
       }
     } catch (error) {
       console.error("유효하지 않은 JSON을 변환하려 합니다 :", error);
     }
-  }, [noteData]);
+  }, [noteData, feelsLikeTempData]);
 
   useEffect(() => {
     try {

--- a/src/app/pages/EditPage.tsx
+++ b/src/app/pages/EditPage.tsx
@@ -100,33 +100,37 @@ const EditPage = () => {
                 }}
               />
               <Text style={typography.heading2}>{toDateString(date)}</Text>
-              <ToolbarButton
-                name={IconName.check}
-                onPress={async () => {
-                  try {
-                    // 노트를 수정하려는 경우
-                    if (note) {
-                      const prop = {
-                        content: memo,
-                      };
-                    }
-                    // 오늘 노트를 처음 작성하는 경우
-                    else {
-                      const prop = {
-                        location: "Seoul",
-                        content: memo,
-                        custom_temp: myMoodOndo,
-                      };
-                      const result = await postNote(prop);
-                      console.log(result);
-                    }
+              {editable ? (
+                <ToolbarButton
+                  name={IconName.check}
+                  onPress={async () => {
+                    try {
+                      // 노트를 수정하려는 경우
+                      if (note) {
+                        const prop = {
+                          content: memo,
+                        };
+                      }
+                      // 오늘 노트를 처음 작성하는 경우
+                      else {
+                        const prop = {
+                          location: "Seoul",
+                          content: memo,
+                          custom_temp: myMoodOndo,
+                        };
+                        const result = await postNote(prop);
+                        console.log(result);
+                      }
 
-                    router.back();
-                  } catch (error) {
-                    console.error("ERROR : ", error);
-                  }
-                }}
-              />
+                      router.back();
+                    } catch (error) {
+                      console.error("ERROR : ", error);
+                    }
+                  }}
+                />
+              ) : (
+                <View style={{ width: 44 }} />
+              )}
             </View>
             <LocationAndTemperature
               location={"서울특별시"}
@@ -134,24 +138,29 @@ const EditPage = () => {
             />
           </View>
 
-          <View style={{ marginTop: 16 }}>
-            <TemperatureSlider
-              feelsLikeTemp={feelsLikeTemp}
-              moodTemp={myMoodOndo}
-              // TODO: 만약 note 정보가 있다면 해당 날짜에 선택한 온도 넣어주기
-              changeMoodTemp={(temperature) => {
-                setMyMoodOndo(temperature);
-              }}
-            />
-          </View>
-          <View style={{ flex: 1 }}>
-            <NoteEditor
-              keywordList={["키워드 1", "keyword", "hello"]}
-              memo={memo}
-              onMemoChanged={(memo) => setMemo(memo)}
-              defaultValue={note?.content}
-              autoFocus={!note}
-            />
+          <View
+            pointerEvents={editable ? "auto" : "none"}
+            style={{ marginTop: 16, flex: 1, gap: 12 }}
+          >
+            <View>
+              <TemperatureSlider
+                feelsLikeTemp={feelsLikeTemp}
+                moodTemp={myMoodOndo}
+                // TODO: 만약 note 정보가 있다면 해당 날짜에 선택한 온도 넣어주기
+                changeMoodTemp={(temperature) => {
+                  setMyMoodOndo(temperature);
+                }}
+              />
+            </View>
+            <View style={{ flex: 1 }}>
+              <NoteEditor
+                keywordList={["키워드 1", "keyword", "hello"]}
+                memo={memo}
+                onMemoChanged={(memo) => setMemo(memo)}
+                defaultValue={note?.content}
+                autoFocus={!note}
+              />
+            </View>
           </View>
         </KeyboardAvoidingView>
       </SafeAreaView>

--- a/src/components/editpage/NoteEditor.tsx
+++ b/src/components/editpage/NoteEditor.tsx
@@ -1,5 +1,5 @@
 import { StyleSheet, Text, TextInput, View } from "react-native";
-import React from "react";
+import React, { forwardRef } from "react";
 import { Colors } from "@/src/styles/Colors";
 import Keywords from "./Keywords";
 import typography from "@/src/styles/Typography";
@@ -12,40 +12,46 @@ type NoteEditorProps = {
   defaultValue?: string;
 };
 
-const NoteEditor = ({
-  keywordList,
-  memo,
-  onMemoChanged,
-  autoFocus = true,
-  defaultValue = "",
-}: NoteEditorProps) => {
-  return (
-    <View style={styles.noteEditorContainer}>
-      <View style={{ flex: 1 }}>
-        <Keywords keywordList={keywordList} />
-        <TextInput
-          defaultValue={defaultValue}
-          style={styles.noteEditor}
-          multiline={true}
-          numberOfLines={3}
-          maxLength={100}
-          placeholder={
-            "오늘 나만의 온도는 어땠나요?\n오늘의 하루를 컬러와 간단한 문장으로 표현해보세요."
-          }
-          placeholderTextColor={Colors.black40}
-          autoFocus={autoFocus}
-          onChangeText={(memo) => {
-            onMemoChanged(memo);
-          }}
-        />
+const NoteEditor = forwardRef<TextInput, NoteEditorProps>(
+  (
+    {
+      keywordList,
+      memo,
+      onMemoChanged,
+      autoFocus = false,
+      defaultValue = "",
+    }: NoteEditorProps,
+    ref
+  ) => {
+    return (
+      <View style={styles.noteEditorContainer}>
+        <View style={{ flex: 1 }}>
+          <Keywords keywordList={keywordList} />
+          <TextInput
+            ref={ref}
+            defaultValue={defaultValue}
+            style={styles.noteEditor}
+            multiline={true}
+            numberOfLines={3}
+            maxLength={100}
+            placeholder={
+              "오늘 나만의 온도는 어땠나요?\n오늘의 하루를 컬러와 간단한 문장으로 표현해보세요."
+            }
+            placeholderTextColor={Colors.black40}
+            autoFocus={autoFocus}
+            onChangeText={(memo) => {
+              onMemoChanged(memo);
+            }}
+          />
+        </View>
+        <View style={{ flexDirection: "row", justifyContent: "flex-end" }}>
+          <Text style={styles.noteCountingLabel}>{memo.length}</Text>
+          <Text style={styles.noteMaxLabel}> /100</Text>
+        </View>
       </View>
-      <View style={{ flexDirection: "row", justifyContent: "flex-end" }}>
-        <Text style={styles.noteCountingLabel}>{memo.length}</Text>
-        <Text style={styles.noteMaxLabel}> /100</Text>
-      </View>
-    </View>
-  );
-};
+    );
+  }
+);
 
 export default NoteEditor;
 

--- a/src/components/editpage/TemperatureSlider.tsx
+++ b/src/components/editpage/TemperatureSlider.tsx
@@ -51,7 +51,8 @@ const TemperatureSlider = ({
                   // 체감온도 레이블을 표시할 위치 지정
                   {
                     left: `${
-                      ((feelsLikeTemp - minValue) / (maxValue - minValue)) * 100
+                      ((feelsLikeTemp - minValue) / (maxValue - minValue)) *
+                      99.5
                     }%`,
                   },
                 ]}
@@ -65,7 +66,7 @@ const TemperatureSlider = ({
           </View>
           <Slider
             containerStyle={{ height: 20 }}
-            trackRightPadding={-1}
+            trackRightPadding={1.5}
             minimumValue={minValue}
             maximumValue={maxValue}
             value={moodTemp}
@@ -76,7 +77,7 @@ const TemperatureSlider = ({
             minimumTrackTintColor="transparent"
             thumbStyle={styles.thumb}
             thumbTouchSize={{
-              width: 6,
+              width: 12,
               height: 50,
             }}
             trackStyle={styles.track}
@@ -88,7 +89,9 @@ const TemperatureSlider = ({
         style={[
           styles.sliderThumbContainer,
           {
-            left: `${((moodTemp - minValue) / (maxValue - minValue)) * 100}%`,
+            left: `${
+              ((moodTemp - minValue) / (maxValue - minValue)) * (100 - 0.5)
+            }%`,
           },
         ]}
       >
@@ -136,7 +139,7 @@ const styles = StyleSheet.create({
     flexDirection: "row",
     position: "absolute",
     bottom: -54,
-    transform: [{ translateX: "-22%" }],
+    transform: [{ translateX: "-18%" }],
     alignItems: "center",
   },
   feelsLikeTempLabel: {


### PR DESCRIPTION
## 구현 영상 또는 이미지
|새로운 글 작성 진입|과거 글 진입|오늘 작성한 글 진입|
|---|---|---|
|![Simulator Screen Recording - iPhone 15 Pro - 2025-03-25 at 11 34 20](https://github.com/user-attachments/assets/99445416-3483-4597-ab03-570e54078446)|![Simulator Screen Recording - iPhone 15 Pro - 2025-03-25 at 11 33 54](https://github.com/user-attachments/assets/0cbfca58-37f1-4bf1-a3a1-312f9f25415c)|![Simulator Screen Recording - iPhone 15 Pro - 2025-03-25 at 11 36 28](https://github.com/user-attachments/assets/33e7f141-800c-46ae-986d-fe3eabec5727)|

## 세부 사항
- 3가지 상황에 대해 분기 처리를 하도록 로직을 추가하였습니다. 
  - 과거에 작성한 글을 볼 때 데이터로 초기화되고, TextInput과 Slider가 수정 불가능
  - 오늘 작성한 글을 볼 때 데이터로 초기화되고, TextInput과 Slider가 수정 가능 / 자동으로 키보드를 올리지 않음
  - 오늘 처음 글을 작성할 때, 자동으로 키보드를 올림


## 기타 질문 및 특이 사항
- 기존에 작성한 글의 유무는 EditPage로 들어올 때 props로 note 에 대한 정보를 전달하였는지 (undefined인지) 를 통해 결정합니다.
- 페이지 진입 시 autoFocus를 사용해 키보드를 올려두는 경우 키보드 배경색이 검게 깜빡이는 현상이 있어, 일정 시간(500ms)가 지난 후 키보드가 올라오도록 변경해주었습니다.
 
## 체크 리스트 (아래 사항들이 전부 체크되어야만 merge)
- [x]  필요한 test들을 완료하였고 기능이 제대로 실행되는지 확인 하였습니다.
- [x]  코드 스타일 가이드에 맞추어 코드를 작성 하였습니다.
- [x]  제가 의도한 파일들과 수정 사항들만 커밋이 된 것을 확인 하였습니다.
- [x]  본 수정 사항들을 팀원들과 사전에 상의하였고 팀원들 모두 해당 PR에 대하여 알고 있습니다.
