### PR TITLE
[UI 구현] AlertModal(Dialog) 컴포넌트 추가

### DIFF
--- a/src/components/feedback/AlertModal.tsx
+++ b/src/components/feedback/AlertModal.tsx
@@ -1,0 +1,126 @@
+import { Colors } from "@/src/styles/Colors";
+import typography from "@/src/styles/Typography";
+import {
+  Modal,
+  TouchableOpacity,
+  View,
+  Text,
+  TouchableWithoutFeedback,
+  StyleSheet,
+  ViewStyle,
+  TextStyle,
+} from "react-native";
+
+type AlertModalProps = {
+  isModalVisible: boolean;
+  title?: string;
+  content?: string;
+  primaryLabel?: string;
+  secondaryLabel?: string;
+  onPressPrimary?: () => void;
+  onPressSecondary?: () => void;
+  dismissHandler?: () => void;
+};
+
+const AlertModal = ({
+  isModalVisible,
+  title = "",
+  content = "",
+  primaryLabel = "",
+  secondaryLabel = "",
+  onPressPrimary = () => {},
+  onPressSecondary = () => {},
+  dismissHandler = () => {},
+}: AlertModalProps) => {
+  return (
+    <Modal transparent={true} visible={isModalVisible}>
+      <TouchableWithoutFeedback onPress={dismissHandler}>
+        <View style={styles.modalBackground}>
+          <View style={styles.modalContainer}>
+            <Text style={styles.titleLabel}>{title}</Text>
+            <Text style={styles.contentLabel}>{content}</Text>
+            <View style={{ flexDirection: "row", gap: 16 }}>
+              <TouchableOpacity
+                onPress={onPressSecondary}
+                style={styles.secondaryActionButton}
+              >
+                <Text style={styles.secondaryActionButtonLabel}>
+                  {secondaryLabel}
+                </Text>
+              </TouchableOpacity>
+              <TouchableOpacity
+                onPress={onPressPrimary}
+                style={styles.primaryActionButton}
+              >
+                <Text style={[styles.priamryActionButtonLabel]}>
+                  {primaryLabel}
+                </Text>
+              </TouchableOpacity>
+            </View>
+          </View>
+        </View>
+      </TouchableWithoutFeedback>
+    </Modal>
+  );
+};
+
+export default AlertModal;
+
+const actionButton: ViewStyle = {
+  flex: 1,
+  justifyContent: "center",
+  alignItems: "center",
+  borderRadius: 12,
+  height: 50,
+};
+const actionButtonLabel: ViewStyle | TextStyle = {
+  ...typography.body,
+};
+
+const styles = StyleSheet.create({
+  modalBackground: {
+    backgroundColor: Colors.black40,
+    alignItems: "center",
+    justifyContent: "center",
+    flex: 1,
+  },
+  modalContainer: {
+    width: "90%",
+    backgroundColor: "white",
+    padding: 24,
+    justifyContent: "center",
+    alignItems: "center",
+    borderRadius: 24,
+    gap: 16,
+  },
+  titleLabel: {
+    ...typography.heading2,
+    color: Colors.black100,
+  },
+  contentLabel: {
+    ...typography.body,
+    color: Colors.gray,
+    textAlign: "center",
+  },
+
+  primaryActionButton: {
+    ...actionButton,
+    backgroundColor: Colors.black100,
+    color: Colors.white100,
+  },
+  secondaryActionButton: {
+    ...actionButton,
+    backgroundColor: Colors.lightGray,
+    borderColor: "#EAEDF1",
+    borderWidth: 1,
+    color: Colors.gray,
+  },
+  priamryActionButtonLabel: {
+    ...actionButtonLabel,
+    color: Colors.white100,
+  },
+  secondaryActionButtonLabel: {
+    ...actionButtonLabel,
+    color: Colors.gray,
+  },
+});


### PR DESCRIPTION
## 구현 영상 또는 이미지
|Alert Modal 추가|
|---|
|<img width=300 src="https://github.com/user-attachments/assets/e87a7fce-c699-4a74-90e5-a82784ac9c5f">|


## 세부 사항
- Alert Modal (Dialog) 컴포넌트를 추가하였습니다.
- 아래와 같은 방식으로 각 화면에서 사용 가능합니다. 
```ts
const [isModalVisible, setIsModalVisible] = useState(false);

return (
  <View style={[styles.background]}>
    <SafeAreaView style={styles.safeArea}>
      ...
    </SafeAreaView>
    <AlertModal
      isModalVisible={isModalVisible}
      title="기록을 취소하실건가요?"
      content="이대로 나가면\n작성한 내용이 사라져요"
      primaryLabel="네"
      onPressPrimary={() => {}}
      secondaryLabel="아니요"
      onPressSecondary={() => {}}
      dismissHandler={() => {setIsModalVisible(false)}} // 배경 터치 시 호출하는 메서드
    />
  </View>
);
```

## 기타 질문 및 특이 사항
- StyleSheet에서 공통으로 적용 가능한 스타일에 대해서 다음과 같이 작성하는 방식을 시도해봤습니다.
```ts
const actionButton: ViewStyle = {
  flex: 1,
  justifyContent: "center",
  alignItems: "center",
  borderRadius: 12,
  height: 50,
};

const styles = StyleSheet.create({
  primaryActionButton: {
    ...actionButton,
    backgroundColor: Colors.black100,
    color: Colors.white100,
  },
  secondaryActionButton: {
    ...actionButton,
    backgroundColor: Colors.lightGray,
    borderColor: "#EAEDF1",
    borderWidth: 1,
    color: Colors.gray,
  },
});
```
- 기존에는 공통 스타일인 actionButton과 개별 스타일인 primaryActionButton 스타일을 동시에 적용하기 위해 `style={[actionButton, primaryActionButton]}` 과 같은 형식으로 작성하고 있었는데, 네이밍이나 형식적인 부분에서 동일한 컨텍스트가 중복으로 나오는게 어색하다고 느껴 위와 같이 작성해보았습니다.

- 다만, ViewStyle이 StyleSheet와 묶여있지 않고 외부에 덩그러니 놓여있는 것 같아서 좀 더 개선할 수도 있을 것 같은데, 혹시 공통 스타일을 extends 하면서 자식 스타일을 작성할 수 있는 더 나은 방법이 있을까요?
 
## 체크 리스트 (아래 사항들이 전부 체크되어야만 merge)
- [x]  필요한 test들을 완료하였고 기능이 제대로 실행되는지 확인 하였습니다.
- [x]  코드 스타일 가이드에 맞추어 코드를 작성 하였습니다.
- [x]  제가 의도한 파일들과 수정 사항들만 커밋이 된 것을 확인 하였습니다.
- [x]  본 수정 사항들을 팀원들과 사전에 상의하였고 팀원들 모두 해당 PR에 대하여 알고 있습니다.
