### PR TITLE
[기능 구현] HomePage의 로직 개선 및 SE 사이즈 대응

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "on-the-mood-fe",
   "main": "expo-router/entry",
-  "version": "0.0.0.8",
+  "version": "0.0.11",
   "scripts": {
     "start": "expo start",
     "reset-project": "node ./scripts/reset-project.js",

--- a/src/app/index.tsx
+++ b/src/app/index.tsx
@@ -97,7 +97,8 @@ const styles = StyleSheet.create({
     flexDirection: "row",
     width: "100%",
     paddingHorizontal: 16,
-    paddingVertical: 12,
+    paddingTop: 12,
+    paddingBottom: 24,
     justifyContent: "space-between",
   },
   content: {

--- a/src/components/calendar/Calendar.tsx
+++ b/src/components/calendar/Calendar.tsx
@@ -6,6 +6,7 @@ import { StyleSheet, View } from "react-native";
 import { useNotes } from "@/src/hooks/useNotes";
 import { LocationData } from "@/src/api/endpoints/weather";
 import { useFocusEffect } from "expo-router";
+import React from "react";
 
 interface CalendarProps {
   date: Date;

--- a/src/components/calendar/Calendar.tsx
+++ b/src/components/calendar/Calendar.tsx
@@ -1,5 +1,5 @@
 import { CalendarDatePicker } from "@/src/components/calendar/CalendarDatePicker";
-import { MoodNoteCalendar } from "@/src/components/calendar/MoodNoteCalendar";
+import { CalendarContent } from "@/src/components/calendar/CalendarContent";
 import { getNotes } from "@/src/api/endpoints/daily-notes";
 import { useEffect, useMemo, useState } from "react";
 import { StyleSheet, View } from "react-native";
@@ -41,7 +41,7 @@ const Calendar = ({
     <>
       <View style={styles.container}>
         {/* 캘린더 */}
-        <MoodNoteCalendar
+        <CalendarContent
           changeModalVisible={(isModalOn: boolean) => {
             setModalVisible(isModalOn);
           }}

--- a/src/components/calendar/CalendarContent.tsx
+++ b/src/components/calendar/CalendarContent.tsx
@@ -8,6 +8,7 @@ import TodayNoteCell from "./TodayNoteCell";
 import typography from "@/src/styles/Typography";
 import { getKrWeekday, isDateToday } from "@/src/utils/dateUtils";
 import { LocationData } from "@/src/api/endpoints/weather";
+import { useScreenSize } from "@/src/hooks/useScreenSize";
 
 interface CalendarContentProp {
   date: Date;
@@ -26,12 +27,15 @@ export const CalendarContent = ({
   feelLikeTemp,
   location,
 }: CalendarContentProp) => {
+  // 기기별 ScreenHeight 에 따라 UI를 다르게 보여주기 위해 사용
+  const { isLargeScreen } = useScreenSize();
+
   const isToday = isDateToday(date);
 
   const MonthPicker = (
     <TouchableOpacity onPress={() => changeModalVisible(true)}>
       <View style={{ flexDirection: "row", alignItems: "center" }}>
-        <Text style={styles.monthPickerLabel}>
+        <Text style={[isLargeScreen ? typography.title2 : typography.title3]}>
           {/* month는 1월이 0부터 시작하기 때문에 1 더해줌 */}
           {date.getFullYear().toString()}.
           {(date.getMonth() + 1).toString().padStart(2, "0")}
@@ -47,20 +51,46 @@ export const CalendarContent = ({
   return (
     <View style={{ justifyContent: "space-between", flex: 1 }}>
       <View style={styles.calendarContainer}>
-        {/* 년,월 선택 버튼 */}
-        <Text style={styles.dateLabel}>
-          {date.getDate().toString()}일 {getKrWeekday(date)}요일
-        </Text>
-        {MonthPicker}
+        <View
+          style={[
+            styles.dateLabelContainer,
+            {
+              flexDirection: isLargeScreen ? "column" : "row-reverse",
+              alignItems: isLargeScreen ? "flex-start" : "center",
+              justifyContent: isLargeScreen ? "flex-start" : "space-between",
+            },
+          ]}
+        >
+          {/* 년,월 선택 버튼 */}
+          <Text
+            style={[
+              styles.dateLabel,
+              isLargeScreen ? typography.heading1 : typography.heading2,
+            ]}
+          >
+            {date.getDate().toString()}일 {getKrWeekday(date)}요일
+          </Text>
+          {MonthPicker}
+        </View>
         <View style={{ height: 8 }} />
         <CalendarGrid
           date={date}
           changeDate={changeCalendarDate}
           notes={notes}
         />
-        {/* 투데이 셀 */}
       </View>
-      <View style={[{ height: 224, borderRadius: 16, overflow: "hidden" }]}>
+      {/* 투데이 셀 */}
+      <View
+        style={[
+          {
+            flex: 1,
+            minHeight: 135,
+            maxHeight: 230,
+            borderRadius: 16,
+            overflow: "hidden",
+          },
+        ]}
+      >
         {isToday && notes.get(date.getDate()) == undefined ? (
           <TodayNoteCell
             date={date}
@@ -81,13 +111,14 @@ export const CalendarContent = ({
 
 const styles = StyleSheet.create({
   calendarContainer: {
-    flexGrow: 1,
+    // flexGrow: 1,
     flexDirection: "column",
     justifyContent: "flex-start",
     overflow: "hidden",
   },
-  monthPickerLabel: {
-    ...typography.title2,
+  dateLabelContainer: {
+    flexGrow: 1,
+    overflow: "hidden",
   },
   monthPickerIcon: {
     width: 20,
@@ -99,7 +130,6 @@ const styles = StyleSheet.create({
     marginLeft: 8,
   },
   dateLabel: {
-    ...typography.heading1,
     color: Colors.black40,
   },
 });

--- a/src/components/calendar/CalendarContent.tsx
+++ b/src/components/calendar/CalendarContent.tsx
@@ -52,7 +52,7 @@ export const CalendarContent = ({
           {date.getDate().toString()}일 {getKrWeekday(date)}요일
         </Text>
         {MonthPicker}
-        <View style={{ height: 16 }} />
+        <View style={{ height: 8 }} />
         <CalendarGrid
           date={date}
           changeDate={changeCalendarDate}

--- a/src/components/calendar/CalendarContent.tsx
+++ b/src/components/calendar/CalendarContent.tsx
@@ -1,6 +1,6 @@
 import React from "react";
 import { TouchableOpacity, View, Text, StyleSheet } from "react-native";
-import GridCalendar from "@/src/components/calendar/GridCalendar";
+import CalendarGrid from "@/src/components/calendar/CalendarGrid";
 import ThreadCalendarCell from "./ThreadCalendarCell";
 import Icon, { IconName } from "../Icon";
 import { Colors } from "@/src/styles/Colors";
@@ -9,7 +9,7 @@ import typography from "@/src/styles/Typography";
 import { getKrWeekday, isDateToday } from "@/src/utils/dateUtils";
 import { LocationData } from "@/src/api/endpoints/weather";
 
-interface MoodNoteCalendarProp {
+interface CalendarContentProp {
   date: Date;
   notes: Map<number, NoteItem>;
   feelLikeTemp: number;
@@ -18,14 +18,14 @@ interface MoodNoteCalendarProp {
   changeModalVisible: (isModalOn: boolean) => void;
 }
 
-export const MoodNoteCalendar = ({
+export const CalendarContent = ({
   changeModalVisible: changeModalVisible,
   date,
   changeCalendarDate,
   notes,
   feelLikeTemp,
   location,
-}: MoodNoteCalendarProp) => {
+}: CalendarContentProp) => {
   const isToday = isDateToday(date);
 
   const MonthPicker = (
@@ -52,7 +52,7 @@ export const MoodNoteCalendar = ({
         </Text>
         {MonthPicker}
         <View style={{ height: 16 }} />
-        <GridCalendar
+        <CalendarGrid
           date={date}
           changeDate={changeCalendarDate}
           notes={notes}

--- a/src/components/calendar/CalendarContent.tsx
+++ b/src/components/calendar/CalendarContent.tsx
@@ -33,7 +33,8 @@ export const CalendarContent = ({
       <View style={{ flexDirection: "row", alignItems: "center" }}>
         <Text style={styles.monthPickerLabel}>
           {/* month는 1월이 0부터 시작하기 때문에 1 더해줌 */}
-          {date.getFullYear().toString()}.{(date.getMonth() + 1).toString()}
+          {date.getFullYear().toString()}.
+          {(date.getMonth() + 1).toString().padStart(2, "0")}
         </Text>
 
         <View style={styles.monthPickerIcon}>

--- a/src/components/calendar/CalendarGrid.tsx
+++ b/src/components/calendar/CalendarGrid.tsx
@@ -3,7 +3,8 @@ import { StyleSheet, View, Text, FlatList } from "react-native";
 import {
   CalendarCell,
   EmptyCalendarCell,
-} from "@/src/components/calendar/CalendarGridCell";
+  PlaceholderCalendarCell,
+} from "@components/calendar/CalendarGridCell";
 import { Colors } from "@/src/styles/Colors";
 import typography from "@/src/styles/Typography";
 import {
@@ -41,13 +42,15 @@ export const CalendarGrid = ({
       <FlatList
         data={items}
         renderItem={({ item }) => {
+          let cellDate = new Date(
+            date.getFullYear(),
+            date.getMonth(),
+            item.date
+          );
+
           if (item.date > 0 && item.date <= lastDate) {
             // 1일부터 마지막 날까지
-            let cellDate = new Date(
-              date.getFullYear(),
-              date.getMonth(),
-              item.date
-            );
+
             let isSelected = isSameDay(date, cellDate);
             return (
               <CalendarCell
@@ -58,7 +61,11 @@ export const CalendarGrid = ({
               />
             );
           } else {
-            return <EmptyCalendarCell />;
+            if (item.date > 0 && item.date - lastDate - cellDate.getDay() > 0)
+              return <PlaceholderCalendarCell />;
+            else {
+              return <EmptyCalendarCell />;
+            }
           }
         }}
         keyExtractor={(item) => item.date.toString()}

--- a/src/components/calendar/CalendarGrid.tsx
+++ b/src/components/calendar/CalendarGrid.tsx
@@ -101,7 +101,7 @@ const styles = StyleSheet.create({
     flexDirection: "row",
     flex: 1,
     textAlign: "center",
-    color: Colors.black100,
+    color: Colors.black40,
   },
 });
 

--- a/src/components/calendar/CalendarGrid.tsx
+++ b/src/components/calendar/CalendarGrid.tsx
@@ -3,7 +3,7 @@ import { StyleSheet, View, Text, FlatList } from "react-native";
 import {
   CalendarCell,
   EmptyCalendarCell,
-} from "@components/calendar/GridCalendarCell";
+} from "@/src/components/calendar/CalendarGridCell";
 import { Colors } from "@/src/styles/Colors";
 import typography from "@/src/styles/Typography";
 import {
@@ -12,18 +12,18 @@ import {
   lastDayOfMonth,
 } from "@/src/utils/dateUtils";
 
-interface GridCalendarProps {
+interface CalendarGridProps {
   date: Date;
   changeDate: (newDate: Date) => void;
   notes: Map<number, NoteItem>;
 }
 
 /// props로 입력된 Date가 포함된 월의 달력을 보여준다.
-export const GridCalendar = ({
+export const CalendarGrid = ({
   date,
   changeDate,
   notes,
-}: GridCalendarProps) => {
+}: CalendarGridProps) => {
   // date가 포함된 달의 첫째 날의 요일
   const firstDayOffset = firstDayOfMonth(date).getDay();
   // date가 포함된 달의 마지막 날짜
@@ -98,4 +98,4 @@ const styles = StyleSheet.create({
   },
 });
 
-export default GridCalendar;
+export default CalendarGrid;

--- a/src/components/calendar/CalendarGridCell.tsx
+++ b/src/components/calendar/CalendarGridCell.tsx
@@ -1,6 +1,7 @@
 import { Colors, OndoColors } from "@/src/styles/Colors";
 import typography from "@/src/styles/Typography";
 import { isDateToday } from "@/src/utils/dateUtils";
+import React from "react";
 import { StyleSheet, TouchableOpacity, View, Text } from "react-native";
 
 interface CalendarCellProps {

--- a/src/components/calendar/CalendarGridCell.tsx
+++ b/src/components/calendar/CalendarGridCell.tsx
@@ -76,6 +76,15 @@ export function EmptyCalendarCell() {
   );
 }
 
+// 빈 줄만 채우는 날짜의 캘린더 칸
+export function PlaceholderCalendarCell() {
+  return (
+    <View style={[styles.calendarCell]}>
+      <View />
+    </View>
+  );
+}
+
 const styles = StyleSheet.create({
   calendarCell: {
     flex: 1,

--- a/src/components/calendar/CalendarGridCell.tsx
+++ b/src/components/calendar/CalendarGridCell.tsx
@@ -93,7 +93,8 @@ const styles = StyleSheet.create({
     alignItems: "center",
     justifyContent: "center",
     alignSelf: "center",
-    margin: 6,
+    margin: 4,
+    marginBottom: 12,
   },
   calendarCellText: {
     ...typography.body,

--- a/src/components/calendar/MoodNoteCalendar.tsx
+++ b/src/components/calendar/MoodNoteCalendar.tsx
@@ -6,7 +6,7 @@ import Icon, { IconName } from "../Icon";
 import { Colors } from "@/src/styles/Colors";
 import TodayNoteCell from "./TodayNoteCell";
 import typography from "@/src/styles/Typography";
-import { isDateToday } from "@/src/utils/dateUtils";
+import { getKrWeekday, isDateToday } from "@/src/utils/dateUtils";
 import { LocationData } from "@/src/api/endpoints/weather";
 
 interface MoodNoteCalendarProp {
@@ -33,11 +33,11 @@ export const MoodNoteCalendar = ({
       <View style={{ flexDirection: "row", alignItems: "center" }}>
         <Text style={styles.monthPickerLabel}>
           {/* month는 1월이 0부터 시작하기 때문에 1 더해줌 */}
-          {date.getFullYear().toString()}년 {(date.getMonth() + 1).toString()}월
+          {date.getFullYear().toString()}.{(date.getMonth() + 1).toString()}
         </Text>
 
         <View style={styles.monthPickerIcon}>
-          <Icon name={IconName.downWhite} size={12} />
+          <Icon name={IconName.down} size={12} />
         </View>
       </View>
     </TouchableOpacity>
@@ -47,8 +47,10 @@ export const MoodNoteCalendar = ({
     <View style={{ justifyContent: "space-between", flex: 1 }}>
       <View style={styles.calendarContainer}>
         {/* 년,월 선택 버튼 */}
+        <Text style={styles.dateLabel}>
+          {date.getDate().toString()}일 {getKrWeekday(date)}요일
+        </Text>
         {MonthPicker}
-        <Text style={styles.moodNoteCount}>Mood Note({notes.size})</Text>
         <View style={{ height: 16 }} />
         <GridCalendar
           date={date}
@@ -84,21 +86,19 @@ const styles = StyleSheet.create({
     overflow: "hidden",
   },
   monthPickerLabel: {
-    ...typography.title3,
-    fontWeight: 800,
+    ...typography.title2,
   },
   monthPickerIcon: {
-    width: 24,
-    height: 24,
+    width: 20,
+    height: 20,
     borderRadius: 12,
-    backgroundColor: Colors.black100,
+    backgroundColor: Colors.black18,
     alignItems: "center",
     justifyContent: "center",
     marginLeft: 8,
   },
-  moodNoteCount: {
-    ...typography.title3,
-    fontWeight: 600,
+  dateLabel: {
+    ...typography.heading1,
     color: Colors.black40,
   },
 });

--- a/src/components/calendar/thread/ThreadItem.tsx
+++ b/src/components/calendar/thread/ThreadItem.tsx
@@ -6,13 +6,23 @@ import { Thread } from "../../../types/thread";
 import Icon, { IconName } from "../../Icon";
 import { ToolbarButton } from "../../ToolbarButton";
 import { router } from "expo-router";
+import { useScreenSize } from "../../../hooks/useScreenSize";
 
 const ThreadItem = ({ thread }: { thread: Thread }) => {
   const formattedDate = new Date(thread.updated_at).getDate(); // 예: 24
   const bgColor = OndoColors.get(thread.custom_temp) || "#fff";
+  const { isLargeScreen } = useScreenSize();
 
   return (
-    <View style={[styles.container, { backgroundColor: bgColor }]}>
+    <View
+      style={[
+        styles.container,
+        { backgroundColor: bgColor },
+        isLargeScreen
+          ? styles.largeScreenContainer
+          : styles.smallScreenContainer,
+      ]}
+    >
       {/* 왼쪽: 온도 정보 */}
       <View style={styles.leftBox}>
         <View>
@@ -104,6 +114,18 @@ const styles = StyleSheet.create({
     borderRadius: 12,
     marginHorizontal: 15,
     marginBottom: 8,
+    minHeight: 224,
+    height: 224,
+  },
+  largeScreenContainer: {
+    // 800px 이상 화면용 스타일
+    marginHorizontal: 20,
+    minHeight: 250,
+    height: 250,
+  },
+  smallScreenContainer: {
+    // 800px 미만 화면용 스타일
+    marginHorizontal: 15,
     minHeight: 224,
     height: 224,
   },

--- a/src/hooks/useScreenSize.ts
+++ b/src/hooks/useScreenSize.ts
@@ -1,0 +1,28 @@
+import { useState, useEffect } from 'react';
+import { Dimensions } from 'react-native';
+
+export const useScreenSize = () => {
+  const [screenHeight, setScreenHeight] = useState(Dimensions.get('window').height);
+  const [screenWidth, setScreenWidth] = useState(Dimensions.get('window').width);
+
+  useEffect(() => {
+    const subscription = Dimensions.addEventListener('change', ({ window }) => {
+      setScreenHeight(window.height);
+      setScreenWidth(window.width);
+    });
+
+    return () => subscription?.remove();
+  }, []);
+
+  const isLargeScreen = screenHeight >= 800;
+  const isMediumScreen = screenHeight >= 600 && screenHeight < 800;
+  const isSmallScreen = screenHeight < 600;
+
+  return {
+    screenHeight,
+    screenWidth,
+    isLargeScreen,
+    isMediumScreen,
+    isSmallScreen,
+  };
+}; 

--- a/src/utils/dateUtils.ts
+++ b/src/utils/dateUtils.ts
@@ -47,3 +47,9 @@ export const toDateString = (date: Date): string => {
   const day = date.getDate().toString().padStart(2, "0");
   return `${year}.${month}.${day}.`;
 };
+
+const weekdayKR = ['일', '월', '화', '수', '목', '금', '토'];
+
+export const getKrWeekday = (date: Date): string => {
+  return weekdayKR[date.getDay()];
+}


### PR DESCRIPTION
## 구현 영상 또는 이미지
|SE|기본|
|---|---|
|<img src="https://github.com/user-attachments/assets/4d5951b6-f1b9-4985-ac4d-f3cdb3cb3f28" width=300>|<img src="https://github.com/user-attachments/assets/29dc7c6e-72a8-4b56-a103-04a1e60572cf" width=300>|


## 세부 사항
- 캘린더 관련 컴포넌트의 네이밍 수정
- Screen Height 800px 기준으로 UI 분기

## 기타 질문 및 특이 사항
- 하단의 오늘의 날씨 및 기록하기 버튼은 쓰레드 UI 컴포넌트를 그대로 적용해줄 부분이라, 변경없이 두었습니다. @Junghoon-P 

 
## 체크 리스트 (아래 사항들이 전부 체크되어야만 merge)
- [x]  필요한 test들을 완료하였고 기능이 제대로 실행되는지 확인 하였습니다.
- [x]  코드 스타일 가이드에 맞추어 코드를 작성 하였습니다.
- [x]  제가 의도한 파일들과 수정 사항들만 커밋이 된 것을 확인 하였습니다.
- [x]  본 수정 사항들을 팀원들과 사전에 상의하였고 팀원들 모두 해당 PR에 대하여 알고 있습니다.
