### PR TITLE
[UI 구현] 스레드 변경 디자인 적용 및 캘린더뷰 적용

### DIFF
--- a/src/components/calendar/ThreadCalendarCell.tsx
+++ b/src/components/calendar/ThreadCalendarCell.tsx
@@ -1,12 +1,12 @@
+import { LocationData } from "@/src/api/endpoints/weather";
 import { Colors } from "@/src/styles/Colors";
 import typography from "@/src/styles/Typography";
-import React, { useEffect } from "react";
+import { isDateToday } from "@/src/utils/dateUtils";
+import { router } from "expo-router";
+import React from "react";
 import { StyleSheet, Text, View } from "react-native";
 import Icon, { IconName } from "../Icon";
 import { ToolbarButton } from "../ToolbarButton";
-import { router } from "expo-router";
-import { isDateToday } from "@/src/utils/dateUtils";
-import { LocationData } from "@/src/api/endpoints/weather";
 
 type ThreadCalendarCellProps = {
   date: Date;
@@ -21,24 +21,33 @@ const ThreadCalendarCell = ({
 }: ThreadCalendarCellProps) => {
   const WeatherCell = (
     <View style={[styles.todayCell]}>
-      <Text style={styles.todayCellTitle}>
-        {date.getDate() + " Day \nOndo"}
-      </Text>
+      <Text style={styles.todayCellTitle}>{"오늘의 \n체감 온도"}</Text>
       <View style={{ width: "100%" }}>
-        <View style={{ flexDirection: "row", alignItems: "center" }}>
+        <View
+          style={{
+            flexDirection: "row",
+            alignItems: "center",
+            marginBottom: 4,
+          }}
+        >
           <Icon name={IconName.location} size={17} />
-          <Text style={styles.todayWeatherLocation}>{location?.name_ko}</Text>
+          <Text style={[styles.todayWeatherLocation]}>{location?.name_ko}</Text>
         </View>
-        <Text style={styles.todayWeatherTemperature}>
-          {note?.custom_temp ?? "-"}°
-        </Text>
+        <Text style={[styles.temperature, typography.title1]}>{77}°</Text>
+        <View style={styles.feelsLikeBox}>
+          <Icon name={IconName.temperature} size={16} />
+          <Text style={[styles.feelsLikeText, typography.label2]}>
+            체감 {note?.custom_temp}°
+          </Text>
+        </View>
       </View>
     </View>
   );
+
   const NoteCell = (
     <View style={[styles.todayCell]}>
       <View style={{ flexDirection: "row", paddingHorizontal: 0 }}>
-        <Text style={styles.todayCellTitle}>{"Today\nMood Note"}</Text>
+        <Text style={styles.todayCellTitle}>{"무드온도\n일기"}</Text>
         {note !== undefined ? (
           <ToolbarButton
             name={IconName.arrow}
@@ -88,6 +97,7 @@ const styles = StyleSheet.create({
     width: "100%",
     maxHeight: 250,
     columnGap: 1,
+    gap: 2,
   },
   todayCell: {
     width: "100%",
@@ -97,6 +107,7 @@ const styles = StyleSheet.create({
     padding: 16,
     alignItems: "center",
     backgroundColor: Colors.white40,
+    borderRadius: 16,
   },
   todayCellTitle: {
     flex: 1,
@@ -115,11 +126,27 @@ const styles = StyleSheet.create({
   },
   todayWeatherLocation: {
     ...typography.label1,
-    fontWeight: 600,
-    color: Colors.black100,
+    color: Colors.black70,
   },
   todayWeatherTemperature: {
     ...typography.title1,
+    color: Colors.black100,
+  },
+  feelsLikeBox: {
+    flexDirection: "row",
+    alignItems: "center",
+    gap: 2,
+    borderRadius: 8,
+    paddingHorizontal: 6,
+    paddingVertical: 5,
+    marginTop: 4,
+    alignSelf: "flex-start",
+    backgroundColor: Colors.black18,
+  },
+  feelsLikeText: {
+    color: Colors.black70,
+  },
+  temperature: {
     color: Colors.black100,
   },
 });

--- a/src/components/calendar/thread/ThreadItem.tsx
+++ b/src/components/calendar/thread/ThreadItem.tsx
@@ -10,13 +10,21 @@ import { useThreadItemData } from "@/src/hooks/useThreadItemData";
 
 // 온도 정보 박스 컴포넌트
 const TemperatureSection = React.memo(
-  ({ thread, formattedDate }: { thread: Thread; formattedDate: number }) => (
-    <View style={styles.leftBox}>
+  ({
+    thread,
+    formattedDate,
+    backgroundColor,
+  }: {
+    thread: Thread;
+    formattedDate: number;
+    backgroundColor: string;
+  }) => (
+    <View style={[styles.leftBox, { backgroundColor }]}>
       <View>
         <Text style={[styles.dayText, typography.label1]}>
           {formattedDate} Day
         </Text>
-        <Text style={[styles.label, typography.label1]}>기록 온도</Text>
+        <Text style={[styles.dayText, typography.label1]}>기록 온도</Text>
       </View>
       <View>
         <View style={styles.locationContainer}>
@@ -30,11 +38,9 @@ const TemperatureSection = React.memo(
         </Text>
         <View style={styles.feelsLikeBox}>
           <Icon name={IconName.temperature} size={16} />
-          <View>
-            <Text style={[styles.feelsLikeText, typography.label2]}>
-              체감 {thread.custom_temp}°
-            </Text>
-          </View>
+          <Text style={[styles.feelsLikeText, typography.label2]}>
+            체감 {thread.custom_temp}°
+          </Text>
         </View>
       </View>
     </View>
@@ -45,20 +51,18 @@ const TemperatureSection = React.memo(
 const DiarySection = React.memo(
   ({
     thread,
-    formattedDate,
     onPress,
+    backgroundColor,
   }: {
     thread: Thread;
-    formattedDate: number;
     onPress: () => void;
+    backgroundColor: string;
   }) => (
-    <View style={styles.rightBox}>
+    <View style={[styles.rightBox, { backgroundColor }]}>
       <View style={styles.diaryHeader}>
         <View>
-          <Text style={[styles.dayText, typography.label1]}>
-            {formattedDate} Day
-          </Text>
-          <Text style={[styles.label, typography.label1]}>온도 일기</Text>
+          <Text style={[styles.label, typography.label1]}>무드온도</Text>
+          <Text style={[styles.label, typography.label1]}>일기</Text>
         </View>
         <ToolbarButton name={IconName.arrow} size={44} onPress={onPress} />
       </View>
@@ -89,19 +93,20 @@ const ThreadItem = ({ thread }: { thread: Thread }) => {
 
   return (
     <View
-      style={[styles.container, { backgroundColor }]}
+      style={[styles.container]}
       accessibilityRole="button"
       accessibilityLabel={accessibilityLabel}
     >
-      <TemperatureSection thread={thread} formattedDate={formattedDate} />
-
-      {/* 중앙 보더라인 */}
-      <View style={styles.divider} />
+      <TemperatureSection
+        thread={thread}
+        formattedDate={formattedDate}
+        backgroundColor={backgroundColor}
+      />
 
       <DiarySection
         thread={thread}
-        formattedDate={formattedDate}
         onPress={handleDetailPress}
+        backgroundColor={backgroundColor}
       />
     </View>
   );
@@ -110,53 +115,46 @@ const ThreadItem = ({ thread }: { thread: Thread }) => {
 const styles = StyleSheet.create({
   container: {
     flexDirection: "row",
-    borderRadius: 12,
+    borderRadius: 16,
     marginHorizontal: 15,
     marginBottom: 8,
     minHeight: 224,
     height: 224,
     elevation: 1,
-    shadowColor: Colors.black100,
-    shadowOffset: { width: 0, height: 1 },
-    shadowOpacity: 0.1,
-    shadowRadius: 2,
+    gap: 2,
   },
   leftBox: {
     flex: 1,
     padding: 16,
     justifyContent: "space-between",
+    borderRadius: 16,
   },
   rightBox: {
     flex: 1,
-    padding: 16,
     justifyContent: "space-between",
+    padding: 16,
+    borderRadius: 16,
   },
   locationContainer: {
     flexDirection: "row",
     alignItems: "center",
     gap: 4,
+    marginBottom: 4,
   },
   diaryHeader: {
     flexDirection: "row",
     justifyContent: "space-between",
     alignItems: "flex-start",
   },
-  divider: {
-    width: 1,
-    height: 224,
-    backgroundColor: Colors.black18,
-  },
   dayText: {
-    marginBottom: 4,
     color: Colors.black100,
   },
   label: {
-    marginBottom: 4,
-    color: Colors.black70,
+    color: Colors.black100,
   },
   location: {
     color: Colors.black70,
-    marginBottom: 4,
+    fontWeight: "semibold",
   },
   temperature: {
     color: Colors.black100,

--- a/src/components/calendar/thread/Threads.tsx
+++ b/src/components/calendar/thread/Threads.tsx
@@ -67,11 +67,15 @@ const LoadingFooter = React.memo(() => (
 ));
 
 // 섹션 헤더 컴포넌트 분리
-const SectionHeader = React.memo(({ title }: { title: string }) => (
-  <View style={styles.sectionHeader}>
-    <Text style={styles.sectionTitle}>{title}</Text>
-  </View>
-));
+const SectionHeader = React.memo(
+  ({ title, isFirst }: { title: string; isFirst: boolean }) => (
+    <View
+      style={[styles.sectionHeader, !isFirst && styles.sectionHeaderWithMargin]}
+    >
+      <Text style={styles.sectionTitle}>{title}</Text>
+    </View>
+  )
+);
 
 export default function Threads({ updateDate }: ThreadsProps) {
   const { threads, isLoading, error, hasMore, loadMore, refresh } =
@@ -95,10 +99,11 @@ export default function Threads({ updateDate }: ThreadsProps) {
   }, [isLoading]);
 
   const renderSectionHeader = useCallback(
-    ({ section: { title } }: { section: { title: string } }) => (
-      <SectionHeader title={title} />
-    ),
-    []
+    ({ section: { title }, section }: { section: { title: string } }) => {
+      const sectionIndex = sections.findIndex((s) => s.title === title);
+      return <SectionHeader title={title} isFirst={sectionIndex === 0} />;
+    },
+    [sections]
   );
 
   const renderItem = useCallback(
@@ -162,6 +167,9 @@ const styles = StyleSheet.create({
   sectionHeader: {
     paddingBottom: 16,
     paddingHorizontal: 16,
+  },
+  sectionHeaderWithMargin: {
+    marginTop: 32,
   },
   sectionTitle: {
     ...typography.heading2,


### PR DESCRIPTION
## 구현 영상 또는 이미지
| 홈페이지 | 스레드뷰 |
|----------|----------|
| ![홈페이지](https://github.com/user-attachments/assets/0f77fae1-422c-4960-b69c-84a01c3a219f) | ![스레드뷰](https://github.com/user-attachments/assets/3cc0917d-3fba-4b0b-b050-5495ae899819) |

## 세부 사항
- `ver2` 디자인 적용
- `NoteItem` 타입에 `cuton_temp`만 존재하고 `실제 온도`가 없습니다. 데이터 핸들링 flow를 제가 알지 못하여 확인 부탁드립니다. @sm-amoled  cc. @jungminsayho 

## 기타 질문 및 특이 사항
- `스레드뷰`에서 그날의 컬러와 이전 `노트`의 컬러가 동일시 `노트 박스`UI가 보이지 않는 이슈
  - 해당 조건일때 `테두리 색`을 추가하던 대응이 필요합니다.
 
## 체크 리스트 (아래 사항들이 전부 체크되어야만 merge)
- [x]  필요한 test들을 완료하였고 기능이 제대로 실행되는지 확인 하였습니다.
- [x]  코드 스타일 가이드에 맞추어 코드를 작성 하였습니다.
- [x]  제가 의도한 파일들과 수정 사항들만 커밋이 된 것을 확인 하였습니다.
- [x]  본 수정 사항들을 팀원들과 사전에 상의하였고 팀원들 모두 해당 PR에 대하여 알고 있습니다.
