### PR TITLE
[기능 구현] 탈퇴하기 UI 구현 및 로직 연결

### DIFF
--- a/ios/fastlane/report.xml
+++ b/ios/fastlane/report.xml
@@ -5,22 +5,22 @@
     
     
       
-      <testcase classname="fastlane.lanes" name="0: default_platform" time="0.001012">
+      <testcase classname="fastlane.lanes" name="0: default_platform" time="0.001006">
         
       </testcase>
     
       
-      <testcase classname="fastlane.lanes" name="1: increment_version_number" time="1.963498">
+      <testcase classname="fastlane.lanes" name="1: increment_version_number" time="46.388825">
         
       </testcase>
     
       
-      <testcase classname="fastlane.lanes" name="2: build_app" time="787.98577">
+      <testcase classname="fastlane.lanes" name="2: build_app" time="1076.212611">
         
       </testcase>
     
       
-      <testcase classname="fastlane.lanes" name="3: firebase_app_distribution" time="10.068836">
+      <testcase classname="fastlane.lanes" name="3: firebase_app_distribution" time="11.526706">
         
       </testcase>
     

--- a/ios/onthemood/Info.plist
+++ b/ios/onthemood/Info.plist
@@ -17,7 +17,7 @@
 	<key>CFBundlePackageType</key>
 	<string>APPL</string>
 	<key>CFBundleShortVersionString</key>
-	<string>0.0.16</string>
+	<string>0.0.21</string>
 	<key>CFBundleSignature</key>
 	<string>????</string>
 	<key>CFBundleURLTypes</key>

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "onthemood",
-  "version": "0.0.20",
+  "version": "0.0.21",
   "private": true,
   "scripts": {
     "android": "react-native run-android",

--- a/src/api/endpoints/auth.ts
+++ b/src/api/endpoints/auth.ts
@@ -1,7 +1,7 @@
 
 import axiosClient from '../clients/axiosClient';
 import { handleApiError } from '../apiUtils';
-import { getRefreshToken, saveAccessToken, saveRefreshToken, clearAllTokens } from '@/utils/storage';
+import { getRefreshToken, saveAccessToken, saveRefreshToken, clearAllTokens, clearAllUserData } from '@/utils/storage';
 
 interface SignUpProps {
   username: string;
@@ -105,6 +105,22 @@ export const logOut = async () => {
   } catch (error) {
     // 로그아웃 API 실패해도 로컬 토큰은 삭제
     await clearAllTokens();
+    handleApiError(error);
+    throw error;
+  }
+};
+
+// 회원 탈퇴
+export const withdraw = async () => {
+  try {
+    // 서버에 탈퇴 요청
+    await axiosClient.delete('/auth/withdraw');
+    
+    // 로컬의 모든 사용자 데이터 삭제
+    await clearAllUserData();
+  } catch (error) {
+    // 탈퇴 API 실패해도 로컬 데이터는 삭제
+    await clearAllUserData();
     handleApiError(error);
     throw error;
   }

--- a/src/app/index.tsx
+++ b/src/app/index.tsx
@@ -31,6 +31,7 @@ import EditPage from '@/app/pages/EditPage';
 // Profile screens
 import MyPageScreen from '@/app/pages/MyPage';
 import PasswordPage from '@/app/pages/Profile/PasswordPage';
+import WithdrawPage from '@/app/pages/Profile/WithdrawPage';
 
 const Stack = createStackNavigator<RootStackParamList>();
 
@@ -217,6 +218,7 @@ export default function App() {
 
           {/* Profile screens */}
           <Stack.Screen name="PasswordPage" component={PasswordPage} />
+          <Stack.Screen name="WithdrawPage" component={WithdrawPage} />
         </Stack.Navigator>
       </NavigationContainer>
     </BackgroundColorProvider>

--- a/src/app/pages/MyPage.tsx
+++ b/src/app/pages/MyPage.tsx
@@ -25,6 +25,7 @@ import AsyncStorage from '@react-native-async-storage/async-storage';
 import { useBackgroundColor } from '@/hooks/useBackgroundColor';
 import { useNotifications } from '@/hooks/useNotifications';
 import { logOut } from '@/api/endpoints/auth';
+import { getUserProfile } from '@/utils/storage';
 
 // 시간 변환 유틸리티 함수들
 const convertTo24Hour = (notiTime: NotiTime): number => {
@@ -61,7 +62,6 @@ const parseTimeStringToNotiTime = (timeString: string): NotiTime => {
 };
 
 // 상수
-const DEFAULT_USER_EMAIL = 'hello@world.com'; // TODO: 실제 사용자 이메일로 교체
 const PASSWORD_LENGTH = 4;
 
 const MyPage = () => {
@@ -84,6 +84,7 @@ const MyPage = () => {
   });
   const [isPasswordOn, setIsPasswordOn] = useState(false);
   const [modalVisible, setModalVisible] = useState(false);
+  const [userEmail, setUserEmail] = useState(' - '); // 기본값
 
   // 핸들러 함수들
   const handleNotificationToggle = async (value: boolean) => {
@@ -176,6 +177,18 @@ const MyPage = () => {
     }
   };
 
+  // 사용자 프로필 로드
+  useEffect(() => {
+    const loadUserProfile = async () => {
+      const profile = await getUserProfile();
+      if (profile && profile.email) {
+        setUserEmail(profile.email);
+      }
+    };
+
+    loadUserProfile();
+  }, []);
+
   // 페이지가 전환될 때 패스워드가 잘 저장되어있는지 확인
   // 만약 패스워드가 없거나 유효하지 않다면 패스워드가 저장되지 않은 상태로 간주
   useFocusEffect(
@@ -215,7 +228,7 @@ const MyPage = () => {
           {/* 계정 정보 */}
           <View style={styles.section}>
             <SectionContent>
-              <AuthInfo authType={AuthType.apple} email={DEFAULT_USER_EMAIL} />
+              <AuthInfo authType={AuthType.email} email={userEmail} />
             </SectionContent>
           </View>
           {/* 알림 설정 */}
@@ -271,9 +284,7 @@ const MyPage = () => {
                   style={styles.withdrawButton}
                   onPress={() => navigation.navigate('WithdrawPage')}
                 >
-                  <Text style={styles.withdrawLabel}>
-                    탈퇴하기
-                  </Text>
+                  <Text style={styles.withdrawLabel}>탈퇴하기</Text>
                 </TouchableOpacity>
               </>
             ) : null}

--- a/src/app/pages/MyPage.tsx
+++ b/src/app/pages/MyPage.tsx
@@ -252,20 +252,30 @@ const MyPage = () => {
             </SectionContent>
 
             {isPasswordOn ? (
-              <SectionContent>
-                {/* 셀 전체 터치를 위해 label을 child에 포함*/}
+              <>
+                <SectionContent>
+                  {/* 셀 전체 터치를 위해 label을 child에 포함*/}
+                  <TouchableOpacity
+                    style={styles.touchableContainer}
+                    onPress={handlePasswordChange}
+                  >
+                    <View style={styles.rowContainer}>
+                      <Text style={styles.sectionContentLabel}>
+                        비밀번호 변경
+                      </Text>
+                      <Icon name={IconName.arrow} />
+                    </View>
+                  </TouchableOpacity>
+                </SectionContent>
                 <TouchableOpacity
-                  style={styles.touchableContainer}
-                  onPress={handlePasswordChange}
+                  style={styles.withdrawButton}
+                  onPress={() => navigation.navigate('WithdrawPage')}
                 >
-                  <View style={styles.rowContainer}>
-                    <Text style={styles.sectionContentLabel}>
-                      비밀번호 변경
-                    </Text>
-                    <Icon name={IconName.arrow} />
-                  </View>
+                  <Text style={styles.withdrawLabel}>
+                    탈퇴하기
+                  </Text>
                 </TouchableOpacity>
-              </SectionContent>
+              </>
             ) : null}
           </View>
           {/* 계정 관리 */}
@@ -342,5 +352,14 @@ const styles = StyleSheet.create({
     flexDirection: 'row',
     alignItems: 'center',
     justifyContent: 'space-between',
+  },
+  withdrawButton: {
+    paddingVertical: 12,
+    alignItems: 'flex-start',
+  },
+  withdrawLabel: {
+    ...typography.body,
+    color: Colors.black70,
+    textDecorationLine: 'underline',
   },
 });

--- a/src/app/pages/Profile/WithdrawPage.tsx
+++ b/src/app/pages/Profile/WithdrawPage.tsx
@@ -1,0 +1,157 @@
+import {
+  SafeAreaView,
+  StyleSheet,
+  Text,
+  TouchableOpacity,
+  View,
+} from 'react-native';
+import React, { useState } from 'react';
+import { IconName } from '@/components/Icon';
+import Icon from '@/components/Icon';
+import { ToolbarButton } from '@/components/ToolbarButton';
+import { Colors, OndoColors } from '@/styles/Colors';
+import typography from '@/styles/Typography';
+import { useNavigation } from '@react-navigation/native';
+import type { NavigationProp } from '@react-navigation/native';
+import { useBackgroundColor } from '@/hooks/useBackgroundColor';
+import { ActionButton } from '@/components/ActionButton';
+
+const WithdrawPage = () => {
+  const navigation = useNavigation<NavigationProp<any>>();
+  const { colorState } = useBackgroundColor();
+  const [isWithdrawEnabled, setIsWithdrawEnabled] = useState(false);
+
+  return (
+    <View
+      style={{
+        flex: 1,
+        backgroundColor: OndoColors.get(colorState.color),
+      }}
+    >
+      <SafeAreaView style={styles.safeArea}>
+        {/* Toolbar */}
+        <View style={styles.topToolbar}>
+          <ToolbarButton
+            name={IconName.back}
+            onPress={() => {
+              navigation.goBack();
+            }}
+          />
+          <Text
+            style={{
+              ...typography.heading2,
+              color: Colors.black100,
+            }}
+          >
+            화원 탈퇴
+          </Text>
+          <View style={{ width: 44 }} />
+        </View>
+
+        {/* Body Content */}
+        <View style={styles.bodyContainer}>
+          {/* Caution Icon and Title */}
+          <View style={styles.headerSection}>
+            <Icon name={IconName.caution} size={100} color={Colors.black100} />
+            <Text
+              style={[
+                typography.heading2,
+                {
+                  color: Colors.black100,
+                  textAlign: 'center',
+                  marginTop: 32,
+                },
+              ]}
+            >
+              탈퇴 전 확인하세요.
+            </Text>
+          </View>
+
+          {/* Warning Box */}
+          <View style={styles.warningBox}>
+            <Text
+              style={[
+                typography.body2,
+                {
+                  color: Colors.black40,
+                  textAlign: 'center',
+                },
+              ]}
+            >
+              {`가입시 수집한 개인정보(이메일)를 포함하여\n작성한 모든 일기가 영구적으로 삭제되며\n다시는 복구할 수 없습니다.`}
+            </Text>
+          </View>
+        </View>
+        <View>
+          <TouchableOpacity
+            style={styles.textButton}
+            onPress={() => setIsWithdrawEnabled(!isWithdrawEnabled)}
+          >
+            <Icon
+              name={
+                isWithdrawEnabled
+                  ? IconName.checkCircle
+                  : IconName.uncheckCircle
+              }
+              size={24}
+              color={isWithdrawEnabled ? Colors.black100 : Colors.black40}
+            />
+            <Text style={styles.textButtonLabel}>
+              {`안내사항을 확인하였으며 이에 동의합니다`}
+            </Text>
+          </TouchableOpacity>
+          <ActionButton
+            title={'탈퇴하기'}
+            onPress={() => {}}
+            variant={isWithdrawEnabled ? 'default' : 'disabled'}
+          />
+        </View>
+      </SafeAreaView>
+    </View>
+  );
+};
+
+export default WithdrawPage;
+
+const styles = StyleSheet.create({
+  safeArea: {
+    gap: 20,
+    margin: 16,
+    flex: 1,
+  },
+  topToolbar: {
+    flexDirection: 'row',
+    width: '100%',
+    paddingVertical: 12,
+    justifyContent: 'space-between',
+    alignItems: 'center',
+  },
+  bodyContainer: {
+    flex: 1,
+    alignItems: 'center',
+    width: '100%',
+  },
+  headerSection: {
+    alignItems: 'center',
+  },
+  warningBox: {
+    marginTop: 16,
+    borderRadius: 16,
+    paddingHorizontal: 16,
+    paddingVertical: 24,
+    backgroundColor: Colors.black18,
+    alignSelf: 'stretch',
+  },
+  textButton: {
+    flexDirection: 'row',
+    alignItems: 'center',
+    justifyContent: 'center',
+    paddingVertical: 12,
+    gap: 8,
+    marginBottom: 12,
+  },
+  textButtonLabel: {
+    ...typography.body2,
+    color: Colors.black100,
+  },
+});

--- a/src/app/pages/Profile/WithdrawPage.tsx
+++ b/src/app/pages/Profile/WithdrawPage.tsx
@@ -1,4 +1,5 @@
 import {
+  Alert,
   SafeAreaView,
   StyleSheet,
   Text,
@@ -15,11 +16,32 @@ import { useNavigation } from '@react-navigation/native';
 import type { NavigationProp } from '@react-navigation/native';
 import { useBackgroundColor } from '@/hooks/useBackgroundColor';
 import { ActionButton } from '@/components/ActionButton';
+import { withdraw } from '@/api/endpoints/auth';
 
 const WithdrawPage = () => {
   const navigation = useNavigation<NavigationProp<any>>();
   const { colorState } = useBackgroundColor();
   const [isWithdrawEnabled, setIsWithdrawEnabled] = useState(false);
+  const [isLoading, setIsLoading] = useState(false);
+
+  const handleWithdraw = async () => {
+    if (!isWithdrawEnabled || isLoading) return;
+
+    setIsLoading(true);
+    try {
+      await withdraw();
+      // 탈퇴 성공 시 Entrance 페이지로 이동
+      navigation.reset({
+        index: 0,
+        routes: [{ name: 'Entrance' }],
+      });
+    } catch (error) {
+      console.error('회원 탈퇴 실패:', error);
+      Alert.alert('오류', '회원 탈퇴 중 문제가 발생했습니다.');
+    } finally {
+      setIsLoading(false);
+    }
+  };
 
   return (
     <View
@@ -101,9 +123,9 @@ const WithdrawPage = () => {
             </Text>
           </TouchableOpacity>
           <ActionButton
-            title={'탈퇴하기'}
-            onPress={() => {}}
-            variant={isWithdrawEnabled ? 'default' : 'disabled'}
+            title={isLoading ? '처리 중...' : '탈퇴하기'}
+            onPress={handleWithdraw}
+            variant={isWithdrawEnabled && !isLoading ? 'default' : 'disabled'}
           />
         </View>
       </SafeAreaView>

--- a/src/components/myPage/AuthInfo.tsx
+++ b/src/components/myPage/AuthInfo.tsx
@@ -7,6 +7,7 @@ import { Colors } from '@/styles/Colors';
 export enum AuthType {
   'google',
   'apple',
+  'email',
 }
 
 export const AuthInfo = ({
@@ -26,6 +27,10 @@ export const AuthInfo = ({
       break;
     case AuthType.apple:
       iconName = IconName.appleLogo;
+      backgroundColor = Colors.black100;
+      break;
+    case AuthType.email:
+      iconName = IconName.profile;
       backgroundColor = Colors.black100;
       break;
   }

--- a/src/types/navigation.ts
+++ b/src/types/navigation.ts
@@ -23,6 +23,7 @@ export type RootStackParamList = {
   
   // Profile screens
   PasswordPage: undefined;
+  WithdrawPage: undefined;
 };
 
 export type TabParamList = {

--- a/src/utils/storage.ts
+++ b/src/utils/storage.ts
@@ -69,3 +69,23 @@ export const clearAllTokens = async () => {
     console.error('토큰 전체 삭제 실패', error);
   }
 };
+
+// 모든 사용자 데이터 삭제 (탈퇴용)
+export const clearAllUserData = async () => {
+  try {
+    await Promise.all([
+      // 토큰 삭제
+      removeAccessToken(),
+      removeRefreshToken(),
+      // 사용자 설정 삭제
+      AsyncStorage.removeItem('@password'),
+      AsyncStorage.removeItem('@NotiTime'),
+      AsyncStorage.removeItem('@hasCompletedOnboarding'),
+      // 기타 앱 데이터 삭제
+      AsyncStorage.removeItem('@lastSelectedDate'),
+      AsyncStorage.removeItem('@userPreferences'),
+    ]);
+  } catch (error) {
+    console.error('사용자 데이터 전체 삭제 실패', error);
+  }
+};

--- a/src/utils/storage.ts
+++ b/src/utils/storage.ts
@@ -70,6 +70,45 @@ export const clearAllTokens = async () => {
   }
 };
 
+// 사용자 프로필 정보 인터페이스
+interface UserProfile {
+  id: number;
+  nickname?: string;
+  username: string;
+  email: string;
+  is_active: boolean;
+  date_joined: string;
+}
+
+// 사용자 프로필 저장
+export const saveUserProfile = async (profile: UserProfile) => {
+  try {
+    await AsyncStorage.setItem('@userProfile', JSON.stringify(profile));
+  } catch (error) {
+    console.error('사용자 프로필 저장 실패', error);
+  }
+};
+
+// 사용자 프로필 불러오기
+export const getUserProfile = async (): Promise<UserProfile | null> => {
+  try {
+    const profile = await AsyncStorage.getItem('@userProfile');
+    return profile ? JSON.parse(profile) : null;
+  } catch (error) {
+    console.error('사용자 프로필 불러오기 실패', error);
+    return null;
+  }
+};
+
+// 사용자 프로필 삭제
+export const removeUserProfile = async () => {
+  try {
+    await AsyncStorage.removeItem('@userProfile');
+  } catch (error) {
+    console.error('사용자 프로필 삭제 실패', error);
+  }
+};
+
 // 모든 사용자 데이터 삭제 (탈퇴용)
 export const clearAllUserData = async () => {
   try {
@@ -77,6 +116,8 @@ export const clearAllUserData = async () => {
       // 토큰 삭제
       removeAccessToken(),
       removeRefreshToken(),
+      // 사용자 프로필 삭제
+      removeUserProfile(),
       // 사용자 설정 삭제
       AsyncStorage.removeItem('@password'),
       AsyncStorage.removeItem('@NotiTime'),


### PR DESCRIPTION
## 구현 영상 또는 이미지
|탈퇴하기 페이지|
|---|
|<img width="300" alt="Simulator Screenshot - iPhone 15 Pro - 2025-08-25 at 22 54 51" src="https://github.com/user-attachments/assets/b56072af-6eca-4ae0-acde-ec8dace32ec1" />|


## 세부 사항
- 탈퇴하기 UI를 작성하였습니다.
- MyPage로부터 네비게이션을 추가하였습니다.
- 탈퇴하기 API 로직을 연결하였고, 성공 시 로컬에 캐싱된 토큰+정보들을 모두 초기화하도록 구현하였습니다.

## 기타 질문 및 특이 사항
- QA 진행을 위해 선제적으로 version up 및 FB 배포를 진행하였습니다. 
-
 
## 체크 리스트 (아래 사항들이 전부 체크되어야만 merge)
- [x]  필요한 test들을 완료하였고 기능이 제대로 실행되는지 확인 하였습니다.
- [x]  코드 스타일 가이드에 맞추어 코드를 작성 하였습니다.
- [x]  제가 의도한 파일들과 수정 사항들만 커밋이 된 것을 확인 하였습니다.
- [x]  본 수정 사항들을 팀원들과 사전에 상의하였고 팀원들 모두 해당 PR에 대하여 알고 있습니다.
