### PR TITLE
[기능 구현] 이메일로 로그인 구현

### DIFF
--- a/src/api/endpoints/auth.ts
+++ b/src/api/endpoints/auth.ts
@@ -212,3 +212,24 @@ export const completeSignUp = async ({
     throw error;
   }
 };
+
+// 최종 비밀번호 재설정
+export const completeForgotPassword = async ({
+  email,
+  password,
+}: {
+  email: string;
+  password: string;
+}) => {
+  try {
+    const response = await axiosClient.post('/auth/reset-password', {
+      email: email,
+      password: password,
+      password2: password,
+    });
+    return response.data;
+  } catch (error) {
+    handleApiError(error);
+    throw error;
+  }
+};

--- a/src/app/index.tsx
+++ b/src/app/index.tsx
@@ -32,6 +32,8 @@ import EditPage from '@/app/pages/EditPage';
 import MyPageScreen from '@/app/pages/MyPage';
 import PasswordPage from '@/app/pages/Profile/PasswordPage';
 import WithdrawPage from '@/app/pages/Profile/WithdrawPage';
+import ForgotPassword from './pages/Auth/ForgotPassword';
+import SuccessChangePassword from './pages/Auth/SuccessChangePassword';
 
 const Stack = createStackNavigator<RootStackParamList>();
 
@@ -143,14 +145,18 @@ const styles = StyleSheet.create({
 });
 
 export default function App() {
-  const [initialRoute, setInitialRoute] = useState<keyof RootStackParamList | null>(null);
+  const [initialRoute, setInitialRoute] = useState<
+    keyof RootStackParamList | null
+  >(null);
 
   useEffect(() => {
     const checkAppStateAndSetInitialRoute = async () => {
       try {
         // 1. 첫 실행 여부 확인
-        const hasCompletedOnboarding = await AsyncStorage.getItem('@hasCompletedOnboarding');
-        
+        const hasCompletedOnboarding = await AsyncStorage.getItem(
+          '@hasCompletedOnboarding',
+        );
+
         if (!hasCompletedOnboarding) {
           // 첫 실행이면 온보딩부터 시작
           setInitialRoute('Onboarding');
@@ -159,7 +165,7 @@ export default function App() {
 
         // 2. 비밀번호 등록 여부 확인
         const storedPassword = await AsyncStorage.getItem('@password');
-        
+
         if (storedPassword && storedPassword.length === 4) {
           // 비밀번호가 설정되어 있으면 PasswordUnlockPage로 시작
           setInitialRoute('PasswordUnlockPage');
@@ -168,7 +174,7 @@ export default function App() {
 
         // 3. 비밀번호가 없다면 로그인 상태 확인
         const accessToken = await getAccessToken();
-        
+
         if (accessToken) {
           // 로그인되어 있으면 Home으로 시작
           setInitialRoute('Home');
@@ -200,28 +206,36 @@ export default function App() {
             }}
             initialRouteName={initialRoute}
           >
-          {/* Main screens */}
-          <Stack.Screen name="Home" component={HomeScreen} />
-          <Stack.Screen name="MyPage" component={MyPageScreen} />
+            {/* Main screens */}
+            <Stack.Screen name="Home" component={HomeScreen} />
+            <Stack.Screen name="MyPage" component={MyPageScreen} />
 
-          {/* Auth screens */}
-          <Stack.Screen name="Entrance" component={Entrance} />
-          <Stack.Screen name="SignIn" component={SignIn} />
-          <Stack.Screen name="SignUp" component={SignUp} />
-          <Stack.Screen name="Onboarding" component={Onboarding} />
-          <Stack.Screen name="Withdraw" component={Withdraw} />
-          <Stack.Screen name="PasswordUnlockPage" component={PasswordUnlockPage} />
+            {/* Auth screens */}
+            <Stack.Screen name="Entrance" component={Entrance} />
+            <Stack.Screen name="SignIn" component={SignIn} />
+            <Stack.Screen name="SignUp" component={SignUp} />
+            <Stack.Screen name="Onboarding" component={Onboarding} />
+            <Stack.Screen name="Withdraw" component={Withdraw} />
+            <Stack.Screen name="ForgotPassword" component={ForgotPassword} />
+            <Stack.Screen
+              name="PasswordUnlockPage"
+              component={PasswordUnlockPage}
+            />
+            <Stack.Screen
+              name="SuccessChangePassword"
+              component={SuccessChangePassword}
+            />
 
-          {/* Content screens */}
-          <Stack.Screen name="DetailPage" component={DetailPage} />
-          <Stack.Screen name="EditPage" component={EditPage} />
+            {/* Content screens */}
+            <Stack.Screen name="DetailPage" component={DetailPage} />
+            <Stack.Screen name="EditPage" component={EditPage} />
 
-          {/* Profile screens */}
-          <Stack.Screen name="PasswordPage" component={PasswordPage} />
-          <Stack.Screen name="WithdrawPage" component={WithdrawPage} />
-        </Stack.Navigator>
-      </NavigationContainer>
-    </BackgroundColorProvider>
-  </AuthProvider>
+            {/* Profile screens */}
+            <Stack.Screen name="PasswordPage" component={PasswordPage} />
+            <Stack.Screen name="WithdrawPage" component={WithdrawPage} />
+          </Stack.Navigator>
+        </NavigationContainer>
+      </BackgroundColorProvider>
+    </AuthProvider>
   );
 }

--- a/src/app/pages/Auth/ForgotPassword.tsx
+++ b/src/app/pages/Auth/ForgotPassword.tsx
@@ -1,0 +1,147 @@
+import React from 'react';
+import { SafeAreaView, StyleSheet, Text, View } from 'react-native';
+import { IconName } from '@/components/Icon';
+import { ToolbarButton } from '@/components/ToolbarButton';
+import { VerificationStep } from '@/components/auth/VerificationStep';
+import { PasswordStep } from '@/components/auth/PasswordStep';
+import { useForgotPassword } from '@/hooks/useForgotPassword';
+import { EmailStep } from '@/components/auth/EmailStep';
+
+const ForgotPassword = () => {
+  const {
+    currentStep,
+    email,
+    setEmail,
+    verificationCode,
+    setVerificationCode,
+    password,
+    setPassword,
+    confirmPassword,
+    setConfirmPassword,
+    errorMessage,
+    isLoading,
+    handleEmailCheck,
+    handleVerificationCode,
+    handlePasswordReset,
+    goToPreviousStep,
+    clearErrorMessage,
+  } = useForgotPassword();
+
+  const renderCurrentStep = () => {
+    switch (currentStep) {
+      case 'email':
+        return (
+          <EmailStepForReset
+            email={email}
+            setEmail={setEmail}
+            errorMessage={errorMessage}
+            isLoading={isLoading}
+            onNext={handleEmailCheck}
+            onClearError={clearErrorMessage}
+          />
+        );
+      case 'verification':
+        return (
+          <VerificationStepForReset
+            email={email}
+            verificationCode={verificationCode}
+            setVerificationCode={setVerificationCode}
+            errorMessage={errorMessage}
+            isLoading={isLoading}
+            onVerify={handleVerificationCode}
+            onClearError={clearErrorMessage}
+            resendCode={handleEmailCheck}
+          />
+        );
+      case 'password':
+        return (
+          <PasswordStepForReset
+            password={password}
+            setPassword={setPassword}
+            confirmPassword={confirmPassword}
+            setConfirmPassword={setConfirmPassword}
+            errorMessage={errorMessage}
+            isLoading={isLoading}
+            onSubmit={handlePasswordReset}
+            onClearError={clearErrorMessage}
+          />
+        );
+      default:
+        return null;
+    }
+  };
+
+  return (
+    <SafeAreaView style={styles.container}>
+      <View style={styles.topToolbar}>
+        <View style={styles.backButton}>
+          <ToolbarButton name={IconName.back} onPress={goToPreviousStep} />
+        </View>
+        <Text style={styles.title}>비밀번호 재설정</Text>
+      </View>
+      {renderCurrentStep()}
+    </SafeAreaView>
+  );
+};
+
+// EmailStep을 비밀번호 재설정용으로 커스터마이징
+const EmailStepForReset = (props: Parameters<typeof EmailStep>[0]) => {
+  return (
+    <EmailStep
+      {...props}
+      title={['비밀번호를 잊으셨나요?']}
+      buttonText="인증코드 받기"
+      subtitle={'비밀번호 재설정을 위해\n가입한 이메일을 입력해주세요.'}
+    />
+  );
+};
+
+// VerificationStep을 비밀번호 재설정용으로 커스터마이징
+const VerificationStepForReset = (
+  props: Parameters<typeof VerificationStep>[0],
+) => {
+  return (
+    <VerificationStep
+      {...props}
+      title={'비밀번호 재설정을 위해\n보내드린 이메일의 코드를 입력해주세요.'}
+      subtitle={`${props.email} 인증을 위해 아래에 코드를 입력해주세요.`}
+    />
+  );
+};
+
+// PasswordStep을 비밀번호 재설정용으로 커스터마이징
+const PasswordStepForReset = (props: Parameters<typeof PasswordStep>[0]) => {
+  return (
+    <PasswordStep
+      {...props}
+      title={['로그인에 사용할', '새로운 비밀번호를 입력해주세요.']}
+      buttonText="재설정하기"
+    />
+  );
+};
+
+export default ForgotPassword;
+
+const styles = StyleSheet.create({
+  container: {
+    flex: 1,
+    margin: 16,
+  },
+  topToolbar: {
+    position: 'relative',
+    width: '100%',
+    paddingVertical: 12,
+    alignItems: 'center',
+  },
+  backButton: {
+    position: 'absolute',
+    left: 0,
+    zIndex: 1,
+  },
+  title: {
+    fontSize: 20,
+    lineHeight: 24,
+    color: '#1e1e1e',
+    fontWeight: '600',
+  },
+});

--- a/src/app/pages/Auth/PasswordUnlockPage.tsx
+++ b/src/app/pages/Auth/PasswordUnlockPage.tsx
@@ -78,7 +78,7 @@ const PasswordUnlockPage = () => {
           </Text>
           <View style={{ width: 44 }} />
         </View>
-        
+
         {/* 비밀번호 UI */}
         <PasswordIndicator
           label={getIndicatorLabel()}
@@ -89,7 +89,7 @@ const PasswordUnlockPage = () => {
         <PasswordKeypad
           onNextInput={newInput => {
             if (isError) return; // 에러 상태일 때는 입력 무시
-            
+
             switch (true) {
               case newInput >= 0:
                 setPasswordInput(passwordInput.concat(newInput.toString()));

--- a/src/app/pages/Auth/SignIn.tsx
+++ b/src/app/pages/Auth/SignIn.tsx
@@ -212,18 +212,17 @@ const styles = StyleSheet.create({
   safeContainer: {
     flex: 1,
     margin: 16,
+    backgroundColor: 'red',
   },
   container: {
     flex: 1,
   },
   topSection: {
     flex: 1,
-    paddingHorizontal: 20,
-    padding: 16,
+    paddingVertical: 16,
   },
   bottomSection: {
-    paddingHorizontal: 20,
-    paddingBottom: 20,
+    paddingBottom: 16,
   },
   headerContainer: {
     alignItems: 'flex-start',

--- a/src/app/pages/Auth/SignIn.tsx
+++ b/src/app/pages/Auth/SignIn.tsx
@@ -64,15 +64,6 @@ const SignIn = () => {
     return Colors.black32;
   };
 
-  const isButtonDisabled = () => {
-    return (
-      email.length === 0 ||
-      password.length === 0 ||
-      isLoading ||
-      emailFormatError.length > 0
-    );
-  };
-
   return (
     <SafeAreaView style={styles.safeContainer}>
       <View style={styles.topToolbar}>
@@ -159,7 +150,7 @@ const SignIn = () => {
                 </View>
                 <TouchableOpacity
                   style={styles.forgotPasswordButton}
-                  onPress={() => navigation.navigate('PasswordUnlockPage')}
+                  onPress={() => navigation.navigate('ForgotPassword')}
                 >
                   <Text style={styles.forgotPasswordText}>
                     비밀번호가 기억나지 않나요?

--- a/src/app/pages/Auth/SignIn.tsx
+++ b/src/app/pages/Auth/SignIn.tsx
@@ -17,6 +17,7 @@ import { useNavigation } from '@react-navigation/native';
 import type { NavigationProp } from '@react-navigation/native';
 import type { RootStackParamList } from '@/types/navigation';
 import { logIn } from '@/api/endpoints/auth';
+import { Colors } from '@/styles/Colors';
 // 토큰 저장은 endpoint에서 처리
 
 const SignIn = () => {
@@ -57,9 +58,9 @@ const SignIn = () => {
   };
 
   const getInputBorderColor = () => {
-    if (logInResult === 'error' || emailFormatError) return '#F86262';
-    if (isFocused) return '#000000';
-    return '#e0e0e0';
+    if (logInResult === 'error' || emailFormatError) return Colors.error;
+    if (isFocused) return Colors.black100;
+    return Colors.black32;
   };
 
   const isButtonDisabled = () => {

--- a/src/app/pages/Auth/SignIn.tsx
+++ b/src/app/pages/Auth/SignIn.tsx
@@ -18,6 +18,7 @@ import type { NavigationProp } from '@react-navigation/native';
 import type { RootStackParamList } from '@/types/navigation';
 import { logIn } from '@/api/endpoints/auth';
 import { Colors } from '@/styles/Colors';
+import { ActionButton } from '@/components/ActionButton';
 // 토큰 저장은 endpoint에서 처리
 
 const SignIn = () => {
@@ -143,7 +144,7 @@ const SignIn = () => {
                     style={[
                       styles.input,
                       {
-                        borderBottomColor: '#e0e0e0',
+                        borderBottomColor: getInputBorderColor(),
                         borderBottomWidth: 1,
                         paddingLeft: 2,
                         paddingRight: 26,
@@ -169,18 +170,17 @@ const SignIn = () => {
 
             {/* 하단 버튼 영역 */}
             <View style={styles.bottomSection}>
-              <TouchableOpacity
-                style={[
-                  styles.button,
-                  isButtonDisabled() && styles.buttonDisabled,
-                ]}
-                disabled={isButtonDisabled()}
+              <ActionButton
+                title={isLoading ? '로그인 중...' : '로그인'}
                 onPress={async () => {
                   try {
                     setIsLoading(true);
                     await logIn({ username: email, password });
                     setLogInResult('성공');
-                    navigation.reset({ index: 0, routes: [{ name: 'Home' }] });
+                    navigation.reset({
+                      index: 0,
+                      routes: [{ name: 'Home' }],
+                    });
                   } catch (error) {
                     setLogInResult('error');
                     console.error('ERROR : ', error);
@@ -188,16 +188,7 @@ const SignIn = () => {
                     setIsLoading(false);
                   }
                 }}
-              >
-                <Text
-                  style={[
-                    styles.buttonText,
-                    isButtonDisabled() && styles.buttonTextDisabled,
-                  ]}
-                >
-                  {isLoading ? '로그인 중...' : '로그인'}
-                </Text>
-              </TouchableOpacity>
+              />
             </View>
           </View>
         </TouchableWithoutFeedback>
@@ -212,7 +203,6 @@ const styles = StyleSheet.create({
   safeContainer: {
     flex: 1,
     margin: 16,
-    backgroundColor: 'red',
   },
   container: {
     flex: 1,

--- a/src/app/pages/Auth/SuccessChangePassword.tsx
+++ b/src/app/pages/Auth/SuccessChangePassword.tsx
@@ -1,0 +1,73 @@
+import React from 'react';
+import { Text, View, StyleSheet, SafeAreaView } from 'react-native';
+import { useNavigation } from '@react-navigation/native';
+import type { NavigationProp } from '@react-navigation/native';
+import type { RootStackParamList } from '@/types/navigation';
+import Icon, { IconName } from '@/components/Icon';
+import { ActionButton } from '@/components/ActionButton';
+import { Colors } from '@/styles/Colors';
+import typography from '@/styles/Typography';
+
+const SuccessChangePassword = () => {
+  const navigation = useNavigation<NavigationProp<RootStackParamList>>();
+
+  const handleGoToSignIn = () => {
+    navigation.navigate('SignIn');
+  };
+
+  return (
+    <SafeAreaView style={styles.container}>
+      <View style={styles.content}>
+        <View style={styles.iconContainer}>
+          <Icon name={IconName.check} size={80} color={Colors.black100} />
+        </View>
+
+        <Text style={styles.title}>비밀번호 재설정 성공</Text>
+
+        <Text style={styles.subtitle}>
+          비밀번호 변경이 완료되었어요.{'\n'}
+          보안을 위해 로그인을 진행해주세요.
+        </Text>
+      </View>
+
+      <View style={styles.buttonContainer}>
+        <ActionButton title="로그인 하기" onPress={handleGoToSignIn} />
+      </View>
+    </SafeAreaView>
+  );
+};
+
+const styles = StyleSheet.create({
+  container: {
+    flex: 1,
+    backgroundColor: Colors.white100,
+    paddingHorizontal: 16,
+  },
+  content: {
+    flex: 1,
+    justifyContent: 'center',
+    alignItems: 'center',
+    paddingBottom: 100,
+  },
+  iconContainer: {
+    marginBottom: 32,
+  },
+  title: {
+    ...typography.heading2,
+    color: Colors.black100,
+    textAlign: 'center',
+    marginBottom: 16,
+  },
+  subtitle: {
+    ...typography.body2,
+    color: Colors.black40,
+    textAlign: 'center',
+    lineHeight: 24,
+  },
+  buttonContainer: {
+    paddingBottom: 32,
+    paddingHorizontal: 16,
+  },
+});
+
+export default SuccessChangePassword;

--- a/src/components/auth/EmailStep.tsx
+++ b/src/components/auth/EmailStep.tsx
@@ -11,6 +11,8 @@ import {
   TouchableOpacity,
 } from 'react-native';
 import Icon, { IconName } from '../Icon';
+import { ActionButton } from '../ActionButton';
+import { Colors } from '@/styles/Colors';
 
 interface EmailStepProps {
   email: string;
@@ -19,15 +21,21 @@ interface EmailStepProps {
   isLoading: boolean;
   onNext: () => void;
   onClearError?: () => void;
+  title?: string[];
+  subtitle?: string;
+  buttonText?: string;
 }
 
 export const EmailStep = ({
   email,
   setEmail,
   errorMessage,
-  isLoading,
   onNext,
   onClearError,
+  isLoading,
+  title = ['로그인에 사용할', '이메일을 입력해주세요.'],
+  subtitle,
+  buttonText = '인증하기',
 }: EmailStepProps) => {
   const [isFocused, setIsFocused] = useState(false);
   const [emailFormatError, setEmailFormatError] = useState('');
@@ -35,13 +43,13 @@ export const EmailStep = ({
   // 이메일 형식 검증 정규표현식
   const emailRegex = /^[^\s@]+@[^\s@]+\.[^\s@]+$/;
 
-  const validateEmailFormat = (email: string) => {
-    if (email.length === 0) {
+  const validateEmailFormat = (emailValue: string) => {
+    if (emailValue.length === 0) {
       setEmailFormatError('');
       return true;
     }
 
-    if (!emailRegex.test(email)) {
+    if (!emailRegex.test(emailValue)) {
       setEmailFormatError('올바른 이메일 형식을 입력해주세요.');
       return false;
     }
@@ -69,9 +77,13 @@ export const EmailStep = ({
   };
 
   const getInputBorderColor = () => {
-    if (errorMessage || emailFormatError) return '#F86262';
-    if (isFocused) return '#000000';
-    return '#e0e0e0';
+    if (errorMessage || emailFormatError) return Colors.error;
+    if (isFocused) return Colors.black100;
+    return Colors.black32;
+  };
+
+  const getDisplayErrorMessage = () => {
+    return errorMessage || emailFormatError;
   };
 
   const isButtonDisabled = () => {
@@ -81,10 +93,6 @@ export const EmailStep = ({
       errorMessage.length > 0 ||
       emailFormatError.length > 0
     );
-  };
-
-  const getDisplayErrorMessage = () => {
-    return errorMessage || emailFormatError;
   };
 
   return (
@@ -98,8 +106,12 @@ export const EmailStep = ({
           {/* 상단 영역 */}
           <View style={styles.topSection}>
             <View style={styles.headerContainer}>
-              <Text style={styles.stepTitle}>로그인에 사용할</Text>
-              <Text style={styles.stepTitle}>이메일을 입력해주세요.</Text>
+              {title.map((line, index) => (
+                <Text key={index} style={styles.stepTitle}>
+                  {line}
+                </Text>
+              ))}
+              {subtitle && <Text style={styles.stepSubtitle}>{subtitle}</Text>}
             </View>
             <View style={styles.inputContainer}>
               <TextInput
@@ -138,23 +150,11 @@ export const EmailStep = ({
 
           {/* 하단 버튼 영역 */}
           <View style={styles.bottomSection}>
-            <TouchableOpacity
-              style={[
-                styles.button,
-                isButtonDisabled() && styles.buttonDisabled,
-              ]}
+            <ActionButton
+              title={buttonText}
               onPress={onNext}
-              disabled={isButtonDisabled()}
-            >
-              <Text
-                style={[
-                  styles.buttonText,
-                  isButtonDisabled() && styles.buttonTextDisabled,
-                ]}
-              >
-                인증하기
-              </Text>
-            </TouchableOpacity>
+              variant={isButtonDisabled() ? 'disabled' : 'default'}
+            />
           </View>
         </View>
       </TouchableWithoutFeedback>
@@ -168,11 +168,9 @@ const styles = StyleSheet.create({
   },
   topSection: {
     flex: 1,
-    paddingHorizontal: 20,
-    padding: 16,
+    paddingVertical: 16,
   },
   bottomSection: {
-    paddingHorizontal: 20,
     paddingBottom: 20,
   },
   headerContainer: {
@@ -186,6 +184,13 @@ const styles = StyleSheet.create({
     color: '#1e1e1e',
     textAlign: 'left',
     lineHeight: 30,
+  },
+  stepSubtitle: {
+    fontSize: 14,
+    color: '#666666',
+    textAlign: 'left',
+    marginTop: 8,
+    lineHeight: 21,
   },
   inputContainer: {
     position: 'relative',

--- a/src/components/auth/PasswordStep.tsx
+++ b/src/components/auth/PasswordStep.tsx
@@ -11,6 +11,8 @@ import {
   TouchableOpacity,
 } from 'react-native';
 import Icon, { IconName } from '../Icon';
+import { Colors } from '@/styles/Colors';
+import { ActionButton } from '../ActionButton';
 
 interface PasswordStepProps {
   password: string;
@@ -21,6 +23,8 @@ interface PasswordStepProps {
   isLoading: boolean;
   onSubmit: () => void;
   onClearError?: () => void;
+  title?: string[];
+  buttonText?: string;
 }
 
 export const PasswordStep = ({
@@ -32,6 +36,8 @@ export const PasswordStep = ({
   isLoading,
   onSubmit,
   onClearError,
+  title = ['로그인에 사용할', '비밀번호를 입력해주세요.'],
+  buttonText = '시작하기',
 }: PasswordStepProps) => {
   const [isPasswordFocused, setIsPasswordFocused] = useState(false);
   const [isConfirmPasswordFocused, setIsConfirmPasswordFocused] =
@@ -58,9 +64,9 @@ export const PasswordStep = ({
   };
 
   const getInputBorderColor = (isFocused: boolean) => {
-    if (errorMessage) return '#F86262';
-    if (isFocused) return '#1E1E1E';
-    return '#e0e0e0';
+    if (errorMessage) return Colors.error;
+    if (isFocused) return Colors.black100;
+    return Colors.black32;
   };
 
   // 비밀번호 검증 함수들
@@ -102,8 +108,11 @@ export const PasswordStep = ({
           {/* 상단 영역 */}
           <View style={styles.topSection}>
             <View style={styles.headerContainer}>
-              <Text style={styles.stepTitle}>로그인에 사용할</Text>
-              <Text style={styles.stepTitle}>비밀번호를 입력해주세요.</Text>
+              {title.map((line, index) => (
+                <Text key={index} style={styles.stepTitle}>
+                  {line}
+                </Text>
+              ))}
             </View>
 
             {/* 비밀번호 입력 필드 */}
@@ -234,23 +243,11 @@ export const PasswordStep = ({
 
           {/* 하단 버튼 영역 */}
           <View style={styles.bottomSection}>
-            <TouchableOpacity
-              style={[
-                styles.button,
-                isButtonDisabled() && styles.buttonDisabled,
-              ]}
+            <ActionButton
+              title={buttonText}
               onPress={onSubmit}
-              disabled={isButtonDisabled()}
-            >
-              <Text
-                style={[
-                  styles.buttonText,
-                  isButtonDisabled() && styles.buttonTextDisabled,
-                ]}
-              >
-                시작하기
-              </Text>
-            </TouchableOpacity>
+              variant={isButtonDisabled() ? 'disabled' : 'default'}
+            />
           </View>
         </View>
       </TouchableWithoutFeedback>
@@ -264,11 +261,9 @@ const styles = StyleSheet.create({
   },
   topSection: {
     flex: 1,
-    paddingHorizontal: 20,
-    padding: 16,
+    paddingVertical: 16,
   },
   bottomSection: {
-    paddingHorizontal: 20,
     paddingBottom: 20,
   },
   headerContainer: {

--- a/src/components/auth/VerificationStep.tsx
+++ b/src/components/auth/VerificationStep.tsx
@@ -1,3 +1,4 @@
+import { Colors } from '@/styles/Colors';
 import React, { useState, useEffect } from 'react';
 import {
   View,
@@ -11,6 +12,7 @@ import {
   TouchableOpacity,
 } from 'react-native';
 import Toast from 'react-native-toast-message';
+import { ActionButton } from '../ActionButton';
 
 interface VerificationStepProps {
   email: string;
@@ -21,6 +23,8 @@ interface VerificationStepProps {
   onVerify: () => void;
   onClearError?: () => void;
   resendCode: () => void;
+  title?: string;
+  subtitle?: string;
 }
 
 export const VerificationStep = ({
@@ -32,6 +36,8 @@ export const VerificationStep = ({
   onVerify,
   onClearError,
   resendCode,
+  title = '이메일의 코드를 입력해주세요.',
+  subtitle,
 }: VerificationStepProps) => {
   const [isFocused, setIsFocused] = useState(false);
   const [countdown, setCountdown] = useState(180); // 3분 = 180초
@@ -66,9 +72,9 @@ export const VerificationStep = ({
   };
 
   const getInputBorderColor = () => {
-    if (errorMessage) return '#F86262';
-    if (isFocused) return '#000000';
-    return '#e0e0e0';
+    if (errorMessage) return Colors.error;
+    if (isFocused) return Colors.black100;
+    return Colors.black32;
   };
 
   const isButtonDisabled = () => {
@@ -88,9 +94,9 @@ export const VerificationStep = ({
           {/* 상단 영역 */}
           <View style={styles.topSection}>
             <View style={styles.headerContainer}>
-              <Text style={styles.stepTitle}>이메일의 코드를 입력해주세요.</Text>
+              <Text style={styles.stepTitle}>{title}</Text>
               <Text style={styles.stepSubtitle}>
-                {email} 인증을 위해 코드를 입력해주세요.
+                {subtitle || `${email} 인증을 위해 코드를 입력해주세요.`}
               </Text>
             </View>
             <View style={styles.inputContainer}>
@@ -136,23 +142,11 @@ export const VerificationStep = ({
             >
               <Text style={styles.resendText}>인증코드를 받지 못했나요?</Text>
             </TouchableOpacity>
-            <TouchableOpacity
-              style={[
-                styles.button,
-                isButtonDisabled() && styles.buttonDisabled,
-              ]}
+            <ActionButton
+              title="다음"
               onPress={onVerify}
-              disabled={isButtonDisabled()}
-            >
-              <Text
-                style={[
-                  styles.buttonText,
-                  isButtonDisabled() && styles.buttonTextDisabled,
-                ]}
-              >
-                다음
-              </Text>
-            </TouchableOpacity>
+              variant={isButtonDisabled() ? 'disabled' : 'default'}
+            />
           </View>
         </View>
       </TouchableWithoutFeedback>
@@ -166,11 +160,9 @@ const styles = StyleSheet.create({
   },
   topSection: {
     flex: 1,
-    paddingHorizontal: 20,
-    padding: 16,
+    paddingVertical: 16,
   },
   bottomSection: {
-    paddingHorizontal: 20,
     paddingBottom: 20,
   },
   headerContainer: {
@@ -190,6 +182,7 @@ const styles = StyleSheet.create({
     color: '#666666',
     textAlign: 'left',
     marginTop: 8,
+    lineHeight: 21,
   },
   inputContainer: {
     position: 'relative',

--- a/src/hooks/useForgotPassword.ts
+++ b/src/hooks/useForgotPassword.ts
@@ -1,0 +1,128 @@
+import { useState } from 'react';
+import { useNavigation } from '@react-navigation/native';
+import type { NavigationProp } from '@react-navigation/native';
+import {
+  sendVerificationCode,
+  verifyEmailCode,
+  completeForgotPassword,
+} from '@/api/endpoints/auth';
+
+type ForgotPasswordStep = 'email' | 'verification' | 'password';
+
+export const useForgotPassword = () => {
+  const navigation = useNavigation<NavigationProp<any>>();
+  const [currentStep, setCurrentStep] = useState<ForgotPasswordStep>('email');
+  const [email, setEmail] = useState('');
+  const [verificationCode, setVerificationCode] = useState('');
+  const [password, setPassword] = useState('');
+  const [confirmPassword, setConfirmPassword] = useState('');
+  const [errorMessage, setErrorMessage] = useState('');
+  const [isLoading, setIsLoading] = useState(false);
+
+  const handleEmailCheck = async () => {
+    if (!email) {
+      setErrorMessage('이메일을 입력해주세요.');
+      return;
+    }
+
+    setIsLoading(true);
+    setErrorMessage('');
+
+    try {
+      // 비밀번호 재설정을 위한 인증코드 발송
+      await sendVerificationCode(email);
+      setCurrentStep('verification');
+    } catch (error: any) {
+      if (error.response?.status === 404) {
+        setErrorMessage('등록되지 않은 이메일입니다.');
+      } else {
+        setErrorMessage('이메일 확인 중 오류가 발생했습니다.');
+      }
+    } finally {
+      setIsLoading(false);
+    }
+  };
+
+  const handleVerificationCode = async () => {
+    if (!verificationCode) {
+      setErrorMessage('인증 코드를 입력해주세요.');
+      return;
+    }
+
+    setIsLoading(true);
+    setErrorMessage('');
+
+    try {
+      await verifyEmailCode(email, verificationCode);
+      setCurrentStep('password');
+    } catch (error) {
+      setErrorMessage('잘못된 인증코드입니다. 다시 입력해주세요.');
+    } finally {
+      setIsLoading(false);
+    }
+  };
+
+  const handlePasswordReset = async () => {
+    if (!password || !confirmPassword) {
+      setErrorMessage('비밀번호를 입력해주세요.');
+      return;
+    }
+
+    if (password !== confirmPassword) {
+      setErrorMessage('비밀번호가 일치하지 않습니다.');
+      return;
+    }
+
+    if (password.length < 8) {
+      setErrorMessage('비밀번호는 8자 이상이어야 합니다.');
+      return;
+    }
+
+    setIsLoading(true);
+    setErrorMessage('');
+
+    try {
+      await completeForgotPassword({ email, password });
+      navigation.navigate('SuccessChangePassword');
+    } catch (error) {
+      setErrorMessage('비밀번호 재설정 중 오류가 발생했습니다.');
+    } finally {
+      setIsLoading(false);
+    }
+  };
+
+  const goToPreviousStep = () => {
+    if (currentStep === 'email') {
+      navigation.goBack();
+    } else if (currentStep === 'verification') {
+      setCurrentStep('email');
+      setErrorMessage('');
+    } else {
+      setCurrentStep('verification');
+      setErrorMessage('');
+    }
+  };
+
+  const clearErrorMessage = () => {
+    setErrorMessage('');
+  };
+
+  return {
+    currentStep,
+    email,
+    setEmail,
+    verificationCode,
+    setVerificationCode,
+    password,
+    setPassword,
+    confirmPassword,
+    setConfirmPassword,
+    errorMessage,
+    isLoading,
+    handleEmailCheck,
+    handleVerificationCode,
+    handlePasswordReset,
+    goToPreviousStep,
+    clearErrorMessage,
+  };
+};

--- a/src/styles/Colors.ts
+++ b/src/styles/Colors.ts
@@ -14,6 +14,7 @@ export const Colors = {
   white40: '#FFFFFF66',
   white100: '#FFFFFF',
   modalBackground: '#383838BF',
+  error: '#F86262',
 };
 
 export const OndoColors = new Map<number, string>([

--- a/src/types/navigation.ts
+++ b/src/types/navigation.ts
@@ -3,14 +3,16 @@ export type RootStackParamList = {
   Entrance: undefined;
   SignIn: undefined;
   SignUp: undefined;
+  ForgotPassword: undefined;
+  SuccessChangePassword: undefined;
   Onboarding: undefined;
   Withdraw: undefined;
   PasswordUnlockPage: undefined;
-  
+
   // Main tab screens
   Home: undefined;
   MyPage: undefined;
-  
+
   // Content screens
   DetailPage: {
     noteData?: string;
@@ -20,7 +22,7 @@ export type RootStackParamList = {
     selectedDate?: string;
     existingNote?: string;
   };
-  
+
   // Profile screens
   PasswordPage: undefined;
   WithdrawPage: undefined;


### PR DESCRIPTION
## PR 제목

feat(auth): SignIn 레이아웃/API 리팩터링 및 비밀번호 찾기 링크 추가

## 개요

SignIn 화면을 회원가입 흐름과 동일한 패턴으로 정리하고, API 연동을 간결하게
개선했습니다. 또한 비밀번호 입력 아래에 "비밀번호가 기억나지 않나요?" 링크를
추가하여 `PasswordUnlockPage`로 이동할 수 있게 했습니다.

## 변경사항

- 상단 툴바에 중앙 타이틀 "로그인" 추가, `SafeAreaView` 마진 적용
- 레이아웃을 상단 입력/하단 고정 버튼 구조로 통일, `KeyboardAvoidingView` 적용
- API 연동 단순화: `logIn({ username, password })`만 호출 (토큰/프로필은
  엔드포인트에서 처리)
- 비밀번호 아래 링크 추가 → `PasswordUnlockPage`로 네비게이션
- 스타일 키 추가: `safeContainer`, `topSection`, `bottomSection`, `backButton`,
  `title`, `forgotPasswordText` 등

## 관련 이슈
- "비밀번호 찾기" 클릭시 `PasswordUnlockPage`로 네비게이트 시키는데 이 페이지가 맞는지만 문의드립니다. @sm-amoled 

